### PR TITLE
Custom ICanvas implementation for PDFsharp

### DIFF
--- a/Examples/PDFsharp/App.config
+++ b/Examples/PDFsharp/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Examples/PDFsharp/PDFsharp.csproj
+++ b/Examples/PDFsharp/PDFsharp.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DB6018D4-8B75-4E43-A770-8B2D97B3E415}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PDFsharp</RootNamespace>
+    <AssemblyName>PDFsharp</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Codecrete.SwissQRBill.Generator, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Codecrete.SwissQRBill.Generator.2.1.1\lib\netstandard2.0\Codecrete.SwissQRBill.Generator.dll</HintPath>
+    </Reference>
+    <Reference Include="PdfSharp, Version=1.50.5147.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
+      <HintPath>packages\PDFsharp.1.50.5147\lib\net20\PdfSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="PdfSharp.Charting, Version=1.50.5147.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
+      <HintPath>packages\PDFsharp.1.50.5147\lib\net20\PdfSharp.Charting.dll</HintPath>
+    </Reference>
+    <Reference Include="QrCodeGenerator, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Net.Codecrete.QrCodeGenerator.1.5.0\lib\netstandard2.0\QrCodeGenerator.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Drawing.Common.4.7.0\lib\net461\System.Drawing.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.7.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encoding.CodePages.4.7.0\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="PdfSharpCanvas.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Examples/PDFsharp/PDFsharp.sln
+++ b/Examples/PDFsharp/PDFsharp.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29519.181
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PDFsharp", "PDFsharp.csproj", "{DB6018D4-8B75-4E43-A770-8B2D97B3E415}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DB6018D4-8B75-4E43-A770-8B2D97B3E415}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB6018D4-8B75-4E43-A770-8B2D97B3E415}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB6018D4-8B75-4E43-A770-8B2D97B3E415}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB6018D4-8B75-4E43-A770-8B2D97B3E415}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AADD0FDA-6369-4554-A84D-1A350618A713}
+	EndGlobalSection
+EndGlobal

--- a/Examples/PDFsharp/PdfSharpCanvas.cs
+++ b/Examples/PDFsharp/PdfSharpCanvas.cs
@@ -38,7 +38,7 @@ namespace PDFsharp
 
             XGraphics.TranslateTransform(translateX, translateY);
             if (rotate != 0.0)
-                XGraphics.RotateTransform(rotate);
+                XGraphics.RotateTransform(rotate / System.Math.PI * 180.0);
             if (scaleX != 1.0 || scaleY != 1.0)
                 XGraphics.ScaleTransform(scaleX, scaleY);           
         }

--- a/Examples/PDFsharp/PdfSharpCanvas.cs
+++ b/Examples/PDFsharp/PdfSharpCanvas.cs
@@ -71,7 +71,9 @@ namespace PDFsharp
         public override void LineTo(double x, double y)
         {
             var point = new XPoint(x, y);
+            CurrentPath.StartFigure();
             CurrentPath.AddLine(CurrentPathPoint, point);
+            CurrentPath.CloseFigure();
             CurrentPathPoint = point;
         }
 

--- a/Examples/PDFsharp/PdfSharpCanvas.cs
+++ b/Examples/PDFsharp/PdfSharpCanvas.cs
@@ -1,0 +1,116 @@
+﻿using Codecrete.SwissQRBill.Generator.Canvas;
+using PdfSharp.Drawing;
+using PdfSharp.Pdf;
+
+namespace PDFsharp
+{
+    class PdfSharpCanvas : AbstractCanvas
+    {
+
+        private readonly XGraphics XGraphics;
+        private readonly string FontFamily;
+
+        private XGraphicsPath CurrentPath;
+        private XPoint CurrentPathPoint;
+
+        public PdfSharpCanvas(PdfPage page, string fontFamily)
+        {
+            FontFamily = fontFamily;
+            SetupFontMetrics(FontFamily);
+
+            XGraphics = XGraphics.FromPdfPage(page, XGraphicsPdfPageOptions.Append, XGraphicsUnit.Millimeter, XPageDirection.Downwards);
+
+            // The origin of an XGraphics canvas is in the top left corner, with the y axis pointing downwards.
+            // This transform mirrors the y axis. Unfortunately this also mirrors text output (see workaround in PutText).
+            // XGraphics.FromPdfPage can be called with XPageDirection.Upwards, which is marked as obsolete because it is not implemented properly
+            // it suffers from the same problem as our matrix below.
+            XGraphics.MultiplyTransform(new XMatrix(1.0, 0.0, 0.0, -1.0, 0.0, XGraphics.PageSize.Height));
+
+            // Save the current state so that we can always revert any transformations we apply.
+            XGraphics.Save();
+        }
+
+        public override void SetTransformation(double translateX, double translateY, double rotate, double scaleX, double scaleY)
+        {
+            // Revert to original state, and immediately put this state on the stack again.
+            XGraphics.Restore();
+            XGraphics.Save();
+
+            XGraphics.TranslateTransform(translateX, translateY);
+            if (rotate != 0.0)
+                XGraphics.RotateTransform(rotate);
+            if (scaleX != 1.0 || scaleY != 1.0)
+                XGraphics.ScaleTransform(scaleX, scaleY);           
+        }
+
+        public override void PutText(string text, double x, double y, int fontSize, bool isBold)
+        {
+            var font = new XFont(FontFamily, XUnit.FromPoint(fontSize).Millimeter, isBold ? XFontStyle.Bold : XFontStyle.Regular);
+
+            // With our transformation to mirror the y axis, text printed using DrawString also gets mirrored.
+            // As a workaround we move our current transformation to the x/y position and then mirror the y axis again, and then restore the previous transformation.
+            XGraphics.Save();
+            XGraphics.TranslateTransform(x, y);
+            XGraphics.MultiplyTransform(new XMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0));
+            XGraphics.DrawString(text, font, XBrushes.Black, 0.0, 0.0);
+            XGraphics.Restore();
+        }
+
+        public override void StartPath()
+        {
+            CurrentPath = new XGraphicsPath();
+            CurrentPathPoint = new XPoint(0.0, 0.0);
+        }
+
+        public override void MoveTo(double x, double y)
+        {
+            CurrentPathPoint = new XPoint(x, y);
+        }
+
+        public override void LineTo(double x, double y)
+        {
+            var point = new XPoint(x, y);
+            CurrentPath.AddLine(CurrentPathPoint, point);
+            CurrentPathPoint = point;
+        }
+
+        public override void CubicCurveTo(double x1, double y1, double x2, double y2, double x, double y)
+        {
+            var controlPoint1 = new XPoint(x1, y1);
+            var controlPoint2 = new XPoint(x2, y2);
+            var point = new XPoint(x, y);
+            CurrentPath.AddBezier(CurrentPathPoint, controlPoint1, controlPoint2, point);
+            CurrentPathPoint = point;
+        }
+
+        public override void AddRectangle(double x, double y, double width, double height)
+        {
+            // TODO: Do we need to update CurrentPathPoint here?
+            CurrentPath.AddRectangle(x, y, width, height);
+        }
+
+        public override void CloseSubpath()
+        {
+            // TODO: Anything we need to do here?
+        }
+
+        public override void FillPath(int color)
+        {
+            // TODO: Use color (is it really necessary??)
+            XGraphics.DrawPath(XBrushes.Black, CurrentPath);
+        }
+
+        public override void StrokePath(double strokeWidth, int color)
+        {
+            // TODO: Use color (is it really necessary??)
+            var pen = new XPen(XColors.Black, XUnit.FromPoint(strokeWidth).Millimeter);
+            XGraphics.DrawPath(pen, CurrentPath);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                XGraphics.Dispose();
+        }
+    }
+}

--- a/Examples/PDFsharp/PdfSharpCanvas.cs
+++ b/Examples/PDFsharp/PdfSharpCanvas.cs
@@ -59,6 +59,7 @@ namespace PDFsharp
         public override void StartPath()
         {
             CurrentPath = new XGraphicsPath();
+            CurrentPath.FillMode = XFillMode.Winding;
             CurrentPathPoint = new XPoint(0.0, 0.0);
         }
 
@@ -96,14 +97,12 @@ namespace PDFsharp
 
         public override void FillPath(int color)
         {
-            // TODO: Use color (is it really necessary??)
-            XGraphics.DrawPath(XBrushes.Black, CurrentPath);
+            XGraphics.DrawPath(new XSolidBrush(XColor.FromArgb(color)), CurrentPath);
         }
 
         public override void StrokePath(double strokeWidth, int color)
         {
-            // TODO: Use color (is it really necessary??)
-            var pen = new XPen(XColors.Black, XUnit.FromPoint(strokeWidth).Millimeter);
+            var pen = new XPen(XColor.FromArgb(color), XUnit.FromPoint(strokeWidth).Millimeter);
             XGraphics.DrawPath(pen, CurrentPath);
         }
 

--- a/Examples/PDFsharp/Program.cs
+++ b/Examples/PDFsharp/Program.cs
@@ -1,0 +1,58 @@
+﻿using Codecrete.SwissQRBill.Generator;
+using PdfSharp.Drawing;
+using PdfSharp.Pdf;
+using System.IO;
+
+namespace PDFsharp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            using (var doc = new PdfDocument())
+            {
+                var page = doc.AddPage();
+                using (var graphic = XGraphics.FromPdfPage(page, XGraphicsUnit.Millimeter))
+                {
+                    graphic.DrawString("Test Invoice", new XFont("Arial", 20.0), XBrushes.Black, 20.0, 150.0);
+                }
+                using (var canvas = new PdfSharpCanvas(page, "Arial"))
+                {
+                    QRBill.Draw(Bill, canvas);
+                }
+                doc.Save("Output.pdf");
+            }
+
+            File.WriteAllBytes("OutputOriginal.pdf", QRBill.Generate(Bill));
+        }
+
+        static readonly Bill Bill = new Bill
+		{
+			// creditor data
+			Account = "CH9600781622484102000",
+			Creditor = new Address
+			{
+				Name = "Seemannschaft Rapperswil",
+				AddressLine2 = "8640 Rapperswil",
+				CountryCode = "CH"
+			},
+
+			// payment data
+			Amount = null,
+			Currency = "CHF",
+
+			// more payment data
+			UnstructuredMessage = "Spende",
+
+            // format
+            Format = new BillFormat
+            {
+                 Language = Language.DE,
+                 SeparatorType = SeparatorType.SolidLineWithScissors,
+                 OutputSize = OutputSize.A4PortraitSheet,
+                 GraphicsFormat = GraphicsFormat.PDF,
+                 FontFamily = "Arial"
+            }
+		};
+	}
+}

--- a/Examples/PDFsharp/Properties/AssemblyInfo.cs
+++ b/Examples/PDFsharp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("PDFsharp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PDFsharp")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("db6018d4-8b75-4e43-a770-8b2d97b3e415")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Examples/PDFsharp/packages.config
+++ b/Examples/PDFsharp/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Codecrete.SwissQRBill.Generator" version="2.1.1" targetFramework="net472" />
+  <package id="Net.Codecrete.QrCodeGenerator" version="1.5.0" targetFramework="net472" />
+  <package id="PDFsharp" version="1.50.5147" targetFramework="net472" />
+  <package id="System.Drawing.Common" version="4.7.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" targetFramework="net472" />
+  <package id="System.Text.Encoding.CodePages" version="4.7.0" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
This pull request is related to https://github.com/manuelbl/SwissQRBill.NET/issues/3

Here is an initial ICanvas implementation using PDFsharp.

This is not production ready yet. These are the issues:

- [x] One of the scissor symbols not drawn correctly.
- [x] Cross missing in QR code.
- [x] Individual lines in a path are connected.
- [x] Implementations of FillPath and StrokePath do not respect the color yet. I don't think this is needed, as the QR bill specifications allows only black anyway.

One challenge was that PDFsharp uses a coordinate system with its origin in the top left corner and the y axis pointing downwards. So I needed to apply a transformation to mirror the y axis. But this caused to mirror the actual text output as well. So as a workaround I had to apply additional transformations in PutText. Text looks ok with this workaround, but I'm not sure if the erroneous scissor symbol is related to this coordinate system mess.

I tried a couple of things, but I didn't find a way to resolve any of the issues 1-3 above.
@manuelbl maybe you have some ideas? 