### PR TITLE
Decode the QR billing information in a structured data model

### DIFF
--- a/Generator/Bill.cs
+++ b/Generator/Bill.cs
@@ -177,10 +177,16 @@ namespace Codecrete.SwissQRBill.Generator
         public string UnstructuredMessage { get; set; }
 
         /// <summary>
-        /// Gets or sets the additional structured bill information.
+        /// Gets or sets the text containing the additional structured bill information.
         /// </summary>
-        /// <value>The structured bill information.</value>
-        public string BillInformation { get; set; }
+        /// <value>The structured bill information text.</value>
+        public string BillInformationText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the billing information.
+        /// </summary>
+        /// <value>The structured billing information.</value>
+        public BillInformation BillInformation { get; set; }
 
         /// <summary>
         /// Gets ors sets the alternative payment schemes.
@@ -220,7 +226,7 @@ namespace Codecrete.SwissQRBill.Generator
                    Reference == other.Reference &&
                    EqualityComparer<Address>.Default.Equals(Debtor, other.Debtor) &&
                    UnstructuredMessage == other.UnstructuredMessage &&
-                   BillInformation == other.BillInformation &&
+                   BillInformationText == other.BillInformationText &&
                    SequenceEqual(AlternativeSchemes, other.AlternativeSchemes) &&
                    EqualityComparer<BillFormat>.Default.Equals(Format, other.Format);
         }
@@ -239,7 +245,7 @@ namespace Codecrete.SwissQRBill.Generator
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Reference);
             hashCode = hashCode * -1521134295 + EqualityComparer<Address>.Default.GetHashCode(Debtor);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(UnstructuredMessage);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(BillInformation);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(BillInformationText);
             hashCode = hashCode * -1521134295 + EqualityComparer<List<AlternativeScheme>>.Default.GetHashCode(AlternativeSchemes);
             hashCode = hashCode * -1521134295 + EqualityComparer<BillFormat>.Default.GetHashCode(Format);
             return hashCode;

--- a/Generator/BillInformation.cs
+++ b/Generator/BillInformation.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Codecrete.SwissQRBill.Generator
+{
+    /// <summary>
+    /// Coded information for automated booking of the payment.
+    /// </summary>
+    public class BillInformation
+    {
+        public BillInformation()
+        {
+            VatDetails = new Dictionary<double, double>();
+            VatImportTaxes = new Dictionary<double, double>();
+            Conditions = new Dictionary<double, int>();
+        }
+
+        /// <summary>
+        /// The invoice number.
+        /// </summary>
+        public string InvoiceNumber { get; set; }
+
+        /// <summary>
+        /// The invoice date.
+        /// </summary>
+        public DateTime? InvoiceDate { get; set; }
+
+        /// <summary>
+        /// The customer reference.
+        /// </summary>
+        public string CustomerReference { get; set; }
+
+        /// <summary>
+        /// The UID number.
+        /// <para>
+        /// UID CHE-106.017.086 without the CHE prefix, separator and without MWST/TVA/IVA/VAT suffix.
+        /// </para>
+        /// </summary>
+        public string VatNumber { get; set; }
+
+        /// <summary>
+        /// Date on which the service was provided.
+        /// </summary>
+        public DateTime? VatDate { get; set; }
+
+        /// <summary>
+        /// Start date of the service.
+        /// <para>
+        /// e.g. for a subscription.
+        /// </para>
+        /// </summary>
+        public DateTime? VatStartDate { get; set; }
+
+        /// <summary>
+        /// End date of the service.
+        /// <para>
+        /// e.g. for a subscription.
+        /// </para>
+        /// </summary>
+        public DateTime? VatEndDate { get; set; }
+
+        /// <summary>
+        /// Refers to the invoiced amount, excluding any discount.
+        /// <para>
+        /// Contains either:
+        /// – a single percentage that is to be applied to the whole invoiced amount or
+        /// – a list of the VAT amounts, defined by a percentage rate and a net amount
+        /// </para>
+        /// </summary>
+        public Dictionary<double, double> VatDetails { get; }
+
+        /// <summary>
+        /// Where goods are imported, the import tax can be entered in this field.
+        /// </summary>
+        public Dictionary<double, double> VatImportTaxes { get; }
+
+        /// <summary>
+        /// The payment conditions.
+        /// <para>
+        /// Contains:
+        /// – discount percentage
+        /// – discount deadline (in days)
+        /// </para>
+        /// </summary>
+        public Dictionary<double, int> Conditions { get; }
+
+        /// <summary>
+        /// The due date.
+        /// <para>
+        /// This field is calculated taking in consideration the invoice date and the information contained in Conditions field.
+        /// </para>
+        /// </summary>
+        public DateTime? DueDate
+        {
+            get
+            {
+                // The invoice date has to be indicated and the condition with a percentage rate equal to zero defines the default payment date of the invoice.
+                if (InvoiceDate == null || Conditions == null || !Conditions.ContainsKey(0))
+                    return null;
+
+                return InvoiceDate.Value.AddDays(Conditions[0]);
+            }
+        }
+
+        /// <summary>
+        /// Decodes the raw text of billing information and fills it into a <see cref="BillInformation"/> data structure.
+        /// </summary>
+        /// <param name="text">The raw text of billing information to be decoded.</param>
+        /// <returns>The decoded billing information.</returns>
+        /// <exception cref="QRBillInformationValidationException">If the text could not be decoded or is invalid.</exception>
+        public static BillInformation DecodeBillInformationText(string text)
+        {
+            return BillInformationText.Decode(text);
+        }
+
+    }
+}

--- a/Generator/BillInformationText.cs
+++ b/Generator/BillInformationText.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Globalization;
+
+namespace Codecrete.SwissQRBill.Generator
+{
+    /// <summary>
+    /// Internal class for decoding the billing information.
+    /// </summary>
+    internal class BillInformationText
+    {
+        private const string Separator = "//";
+
+        private const char VatDetailsPairSeparator = ':';
+
+        private const char VatDetailEntriesSeparator = ';';
+
+        private const char ConditionPairSeparator = ':';
+
+        private const char ConditionEntriesSeparator = ';';
+
+        private const char TagSeparator = '/';
+
+        private const string ValuesSeparator = "/";
+
+        private const string PrefixTag = "S1";
+
+        private const string InvoiceNumberTag = "10";
+
+        private const string InvoiceDateTag = "11";
+
+        private const string CustomerReferenceTag = "20";
+
+        private const string VatNumberTag = "30";
+
+        private const string VatDateTag = "31";
+
+        private const string VatDetailsTag = "32";
+
+        private const string VatImportTaxTag = "33";
+
+        private const string ConditionsTag = "40";
+
+        private const string CharactersToReplace = @"\/";
+
+        private const string ReplacedCharacters = "||";
+
+        /// <summary>
+        /// Decodes the specified text and returns the billing information data.
+        /// <para>
+        /// The text is assumed to be in the Syntax definition for the Billing Information of Swico.
+        /// Reference: https://www.paymentstandards.ch/dam/downloads/ig-qr-bill-en.pdf
+        /// </para>
+        /// </summary>
+        /// <param name="text">The text containing the billing information.</param>
+        /// <returns>The decoded bill information.</returns>
+        /// <exception cref="QRBillInformationValidationException">The text is in an invalid format.</exception>
+        public static BillInformation Decode(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return null;
+
+            if (!text.StartsWith($"{Separator}{PrefixTag}",
+                StringComparison.InvariantCultureIgnoreCase))
+                throw new QRBillInformationValidationException($"Raw text has to start with {Separator}{PrefixTag}");
+
+            text = SanitizeRawString(text);
+
+            var billInformation = new BillInformation();
+
+            var entries = text.Split(TagSeparator);
+
+            for (var i = 0; i < entries.Length; i += 2)
+            {
+                if (entries.Length <= i + 1)
+                    break;
+
+                var key = entries[i];
+                var value = entries[i + 1].Replace(ReplacedCharacters, "/");
+
+                switch (key)
+                {
+                    case InvoiceNumberTag:
+                        billInformation.InvoiceNumber = value;
+                        break;
+                    case InvoiceDateTag:
+                        SetInvoiceDate(billInformation, value);
+                        break;
+                    case CustomerReferenceTag:
+                        billInformation.CustomerReference = value;
+                        break;
+                    case VatNumberTag:
+                        billInformation.VatNumber = value;
+                        break;
+                    case VatDateTag:
+                        SetVatDates(billInformation, value);
+                        break;
+                    case VatDetailsTag:
+                        SetVatDetails(billInformation, value);
+                        break;
+                    case VatImportTaxTag:
+                        SetVatImportTax(billInformation, value);
+                        break;
+                    case ConditionsTag:
+                        SetConditions(billInformation, value);
+                        break;
+                }
+            }
+
+            return billInformation;
+        }
+
+        private static void SetInvoiceDate(BillInformation billInformation, string value)
+        {
+            if (value.Length != 6)
+                return;
+
+            var invoiceDate = GetDateValue(value);
+
+            if (invoiceDate.HasValue)
+                billInformation.InvoiceDate = invoiceDate;
+        }
+
+        private static void SetVatDates(BillInformation billInformation, string value)
+        {
+            if (string.IsNullOrEmpty(value) || (value.Length != 6 && value.Length != 12))
+                return;
+
+            if (value.Length == 6)
+            {
+                var vatDate = GetDateValue(value);
+                billInformation.VatDate = vatDate;
+            }
+            else
+            {
+                var vatStartDate = GetDateValue(value.Substring(0, 6));
+                var vatSEndDate = GetDateValue(value.Substring(6, 6));
+                billInformation.VatStartDate = vatStartDate;
+                billInformation.VatEndDate = vatSEndDate;
+            }
+        }
+
+        private static DateTime? GetDateValue(string dateText)
+        {
+            if (!string.IsNullOrEmpty(dateText) &&
+                dateText.Length == 6 &&
+                DateTime.TryParseExact(
+                    dateText,
+                    "yyMMdd",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var date))
+            {
+                return date;
+            }
+
+            return null;
+        }
+
+        private static void SetVatDetails(BillInformation billInformation, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            var vatEntries = value.Split(VatDetailEntriesSeparator);
+
+            if (vatEntries.Length <= 0)
+                return;
+
+            foreach (var vatEntry in vatEntries)
+            {
+                var vatDetails = vatEntry.Split(VatDetailsPairSeparator);
+
+                billInformation.VatDetails.Add(
+                    Convert.ToDouble(vatDetails[0], CultureInfo.InvariantCulture),
+                    vatDetails.Length == 2
+                        ? Convert.ToDouble(vatDetails[1], CultureInfo.InvariantCulture)
+                        : double.NaN);
+            }
+        }
+
+        private static void SetVatImportTax(BillInformation billInformation, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            var vatEntries = value.Split(VatDetailEntriesSeparator);
+
+            if (vatEntries.Length <= 0)
+                return;
+
+            foreach (var vatEntry in vatEntries)
+            {
+                var vatDetails = vatEntry.Split(VatDetailsPairSeparator);
+
+                billInformation.VatImportTaxes.Add(
+                    Convert.ToDouble(vatDetails[0], CultureInfo.InvariantCulture),
+                    vatDetails.Length == 2
+                        ? Convert.ToDouble(vatDetails[1], CultureInfo.InvariantCulture)
+                        : double.NaN);
+            }
+        }
+
+        private static void SetConditions(BillInformation billInformation, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            var conditionEntries = value.Split(ConditionEntriesSeparator);
+
+            if (conditionEntries.Length <= 0)
+                return;
+
+            foreach (var conditionEntry in conditionEntries)
+            {
+                var conditionDetail = conditionEntry.Split(ConditionPairSeparator);
+
+                if (conditionDetail.Length == 2)
+                {
+                    billInformation.Conditions.Add(
+                        Convert.ToDouble(conditionDetail[0], CultureInfo.InvariantCulture),
+                        Convert.ToInt16(conditionDetail[1], CultureInfo.InvariantCulture));
+                }
+            }
+        }
+
+        private static string SanitizeRawString(string rawBillingInformation)
+        {
+            rawBillingInformation = rawBillingInformation.Substring(
+                rawBillingInformation.IndexOf(PrefixTag, StringComparison.InvariantCultureIgnoreCase) +
+                PrefixTag.Length +
+                ValuesSeparator.Length);
+            rawBillingInformation = rawBillingInformation.Replace(CharactersToReplace, ReplacedCharacters);
+
+            return rawBillingInformation;
+        }
+    }
+}

--- a/Generator/BillLayout.cs
+++ b/Generator/BillLayout.cs
@@ -563,15 +563,15 @@ namespace Codecrete.SwissQRBill.Generator
             _reference = FormatReferenceNumber(_bill.Reference);
 
             string info = _bill.UnstructuredMessage;
-            if (_bill.BillInformation != null)
+            if (_bill.BillInformationText != null)
             {
                 if (info == null)
                 {
-                    info = _bill.BillInformation;
+                    info = _bill.BillInformationText;
                 }
                 else
                 {
-                    info = info + "\n" + _bill.BillInformation;
+                    info = info + "\n" + _bill.BillInformationText;
                 }
             }
             if (info != null)

--- a/Generator/QRBillInformationValidationException.cs
+++ b/Generator/QRBillInformationValidationException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Codecrete.SwissQRBill.Generator
+{
+    public class QRBillInformationValidationException : Exception
+    {
+        public QRBillInformationValidationException()
+        {
+        }
+
+        public QRBillInformationValidationException(string message)
+            : base(message)
+        {
+        }
+
+        public QRBillInformationValidationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected QRBillInformationValidationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Generator/QRCodeText.cs
+++ b/Generator/QRCodeText.cs
@@ -65,7 +65,7 @@ namespace Codecrete.SwissQRBill.Generator
             // AddInf
             AppendDataField(_bill.UnstructuredMessage); // Unstrd
             AppendDataField("EPD"); // Trailer
-            AppendDataField(_bill.BillInformation); // StrdBkgInf
+            AppendDataField(_bill.BillInformationText); // StrdBkgInf
 
             // AltPmtInf
             if (_bill.AlternativeSchemes != null && _bill.AlternativeSchemes.Count > 0)
@@ -131,7 +131,7 @@ namespace Codecrete.SwissQRBill.Generator
         /// <exception cref="QRBillValidationException">The text is in an invalid format.</exception>
         public static Bill Decode(string text)
         {
-            string[] lines = SplitLines(text);
+            var lines = SplitLines(text);
             if (lines.Length < 31 || lines.Length > 34)
             {
                 // A line feed at the end is illegal (cf 4.2.3) but found in practice. Don't be too strict.
@@ -156,7 +156,7 @@ namespace Codecrete.SwissQRBill.Generator
                 ThrowSingleValidationError(ValidationConstants.FieldCodingType, ValidationConstants.KeySupportedCodingType);
             }
 
-            Bill billData = new Bill
+            var billData = new Bill
             {
                 Version = Bill.QrBillStandardVersion.V2_0,
 
@@ -195,7 +195,12 @@ namespace Codecrete.SwissQRBill.Generator
                 ThrowSingleValidationError(ValidationConstants.FieldTrailer, ValidationConstants.KeyValidDataStructure);
             }
 
-            billData.BillInformation = lines.Length > 31 ? lines[31] : "";
+            billData.BillInformationText = lines.Length > 31 ? lines[31] : "";
+
+            if (billData.BillInformationText.Length > 0)
+            {
+                billData.BillInformation = BillInformation.DecodeBillInformationText(billData.BillInformationText);
+            }
 
             List<AlternativeScheme> alternativeSchemes = null;
             int numSchemes = lines.Length - 32;

--- a/Generator/Validator.cs
+++ b/Generator/Validator.cs
@@ -201,7 +201,7 @@ namespace Codecrete.SwissQRBill.Generator
 
         private void ValidateAdditionalInformation()
         {
-            string billInformation = _billIn.BillInformation.Trimmed();
+            string billInformation = _billIn.BillInformationText.Trimmed();
             string unstructuredMessage = _billIn.UnstructuredMessage.Trimmed();
 
             if (billInformation != null && (!billInformation.StartsWith("//") || billInformation.Length < 4))
@@ -226,7 +226,7 @@ namespace Codecrete.SwissQRBill.Generator
                 billInformation = CleanedValue(billInformation, ValidationConstants.FieldBillInformation);
                 if (ValidateLength(billInformation, 140, ValidationConstants.FieldBillInformation))
                 {
-                    _billOut.BillInformation = billInformation;
+                    _billOut.BillInformationText = billInformation;
                 }
             }
             else
@@ -243,7 +243,7 @@ namespace Codecrete.SwissQRBill.Generator
                 else
                 {
                     _billOut.UnstructuredMessage = unstructuredMessage;
-                    _billOut.BillInformation = billInformation;
+                    _billOut.BillInformationText = billInformation;
                 }
             }
         }

--- a/GeneratorTest/BasicBillValidationTest.cs
+++ b/GeneratorTest/BasicBillValidationTest.cs
@@ -182,7 +182,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         {
             SourceBill = SampleData.CreateExample1();
             SourceBill.UnstructuredMessage = null;
-            SourceBill.BillInformation = "//AA4567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789x";
+            SourceBill.BillInformationText = "//AA4567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789x";
             Validate();
             AssertSingleErrorMessage(ValidationConstants.FieldBillInformation, "field_value_too_long");
         }
@@ -191,7 +191,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         private void InvalidBillInformation1()
         {
             SourceBill = SampleData.CreateExample1();
-            SourceBill.BillInformation = "ABCD";
+            SourceBill.BillInformationText = "ABCD";
             Validate();
             AssertSingleErrorMessage(ValidationConstants.FieldBillInformation, "bill_info_invalid");
         }
@@ -200,7 +200,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         private void InvalidBillInformation2()
         {
             SourceBill = SampleData.CreateExample1();
-            SourceBill.BillInformation = "//A";
+            SourceBill.BillInformationText = "//A";
             Validate();
             AssertSingleErrorMessage(ValidationConstants.FieldBillInformation, "bill_info_invalid");
         }
@@ -209,7 +209,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         private void TooLongAdditionalInfo()
         {
             SourceBill = SampleData.CreateExample6();
-            Assert.Equal(140, SourceBill.UnstructuredMessage.Length + SourceBill.BillInformation.Length);
+            Assert.Equal(140, SourceBill.UnstructuredMessage.Length + SourceBill.BillInformationText.Length);
             SourceBill.UnstructuredMessage = SourceBill.UnstructuredMessage + "A";
             Validate();
 

--- a/GeneratorTest/BillInformationTest.cs
+++ b/GeneratorTest/BillInformationTest.cs
@@ -1,0 +1,366 @@
+﻿using System;
+using System.Globalization;
+using Codecrete.SwissQRBill.Generator;
+using Xunit;
+
+namespace Codecrete.SwissQRBill.GeneratorTest
+{
+    public class BillInformationTest
+    {
+        [Fact]
+        public void DecodeBillInformationText_EmptyRawString_ReturnsNull()
+        {
+            var billInformation = BillInformation.DecodeBillInformationText(string.Empty);
+
+            Assert.Null(billInformation);
+        }
+
+        [Theory]
+        [InlineData("/S1/10/X.66711")]
+        [InlineData("///S1/10/X.66711")]
+        [InlineData("S1/10/X.66711")]
+        [InlineData("10/X.66711")]
+        public void DecodeBillInformationText_InvalidBillInformation_ExceptionIsThrown(string rawBillInformation)
+        {
+            var exception = Record.Exception(() =>
+                BillInformation.DecodeBillInformationText(rawBillInformation));
+
+            Assert.NotNull(exception);
+            Assert.IsType<QRBillInformationValidationException>(exception);
+        }
+
+        [Theory]
+        [InlineData(@"//S1/10/X.66711\/8824/11/200712/20/MW-2020-04", "X.66711/8824")]
+        [InlineData("//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180508/32/7.7/40/2:10;0:30", "10201409")]
+        public void DecodeBillInformationText_InvoiceNumber_IsMapped(string rawBillInformation,
+            string expectedInvoiceNumber)
+        {
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Equal(expectedInvoiceNumber, billInformation.InvoiceNumber);
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_InvoiceDate_IsMapped()
+        {
+            const string rawBillInformation =
+                "//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180508/32/7.7/40/2:10;0:30";
+            var expectedInvoiceDate = new DateTime(2019, 5, 12);
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Equal(expectedInvoiceDate, billInformation.InvoiceDate);
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_InvalidInvoiceDate_IsNull()
+        {
+            const string rawBillInformation = "//S1/10/10201409/11/192012";
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Null(billInformation.InvoiceDate);
+
+        }
+
+        [Theory]
+        [InlineData("//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180508/32/7.7/40/2:10;0:30",
+            "1400.000-53")]
+        [InlineData(
+            "//S1/10/90015218/11/200113/20/Ihre Lieferung vom 10.12.2019/30/106017086/31/200113/32/7.7:120/40/0:0",
+            "Ihre Lieferung vom 10.12.2019")]
+        public void DecodeBillInformationText_CustomerReference_IsMapped(string rawBillInformation,
+            string expectedCustomerReference)
+        {
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Equal(expectedCustomerReference, billInformation.CustomerReference);
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_VatNumber_IsMapped()
+        {
+            const string rawBillInformation = "//S1/10/10201409/11/190512/20/1400.000-53/30/106017086";
+            const string expectedVatNumber = "106017086";
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Equal(expectedVatNumber, billInformation.VatNumber);
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_NoVatNumber_IsNull()
+        {
+            const string rawBillInformation = "//S1/10/10201409/11/190512/20/1400.000-53/31/180508";
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Null(billInformation.VatNumber);
+
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_VatDate_IsMapped()
+        {
+            const string rawBillInformation =
+                "//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180508/32/7.7/40/2:10;0:30";
+            var expectedVatDate = new DateTime(2018, 5, 8);
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Equal(expectedVatDate, billInformation.VatDate);
+            Assert.Null(billInformation.VatStartDate);
+            Assert.Null(billInformation.VatEndDate);
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_NoVatDate_AllVatDatesAreMNull()
+        {
+            const string rawBillInformation = "//S1/10/10201409/11/190512";
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Null(billInformation.VatDate);
+            Assert.Null(billInformation.VatStartDate);
+            Assert.Null(billInformation.VatEndDate);
+        }
+
+        [Theory]
+        [InlineData("//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/182008/32/7.7/40/2:10;0:30")]
+        [InlineData("//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/18010800")]
+        public void DecodeBillInformationText_InvalidVatDate_AllVatDatesAreMNull(string rawBillInformation)
+        {
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Null(billInformation.VatDate);
+            Assert.Null(billInformation.VatStartDate);
+            Assert.Null(billInformation.VatEndDate);
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_VatStartEndDate_AreMapped()
+        {
+            const string rawBillInformation =
+                "//S1/10/10104/11/180228/30/395856455/31/180226180227/32/3.7:400.19;7.7:553.39;0:14/40/0:30";
+            var expectedVatStartDate = new DateTime(2018, 2, 26);
+            var expectedVatEndDate = new DateTime(2018, 2, 27);
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Null(billInformation.VatDate);
+            Assert.Equal(expectedVatStartDate, billInformation.VatStartDate);
+            Assert.Equal(expectedVatEndDate, billInformation.VatEndDate);
+        }
+
+        [Theory]
+        [InlineData("//S1/10/10104/11/180228/30/395856455/31/183226180227")]
+        public void DecodeBillInformationText_InvalidVatStartDate_VatStartDateIsNull(string rawBillInformation)
+        {
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Null(billInformation.VatStartDate);
+        }
+
+        [Theory]
+        [InlineData("//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180108000000")]
+        [InlineData("//S1/10/10104/11/180228/30/395856455/31/180226182227")]
+        [InlineData("//S1/10/10104/11/180228/30/395856455/31/18022618022700")]
+        public void DecodeBillInformationText_InvalidVatEndDate_VatEndDateIsNull(string rawBillInformation)
+        {
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Null(billInformation.VatEndDate);
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_VatDetailsSingleVatRate_IsMapped()
+        {
+            const string rawBillInformation =
+                "//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180508/32/7.7/40/2:10;0:30";
+            const double expectedVatRate = 7.7;
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Collection(billInformation.VatDetails,
+                item =>
+                {
+                    Assert.Equal(expectedVatRate, item.Key);
+                    Assert.Equal(double.NaN, item.Value);
+                });
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_NoVatDetails_AreEmpty()
+        {
+            const string rawBillInformation =
+                "//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180508/40/2:10;0:30";
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Empty(billInformation.VatDetails);
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_VatDetails_AreMapped()
+        {
+            const string rawBillInformation =
+                "//S1/10/10104/11/180228/30/395856455/31/180226180227/32/3.7:400.19;7.7:553.39;0:14/40/0:30";
+            const double expectedFirstVatRate = 3.7;
+            const double expectedFirstAmount = 400.19;
+            const double expectedSecondVatRate = 7.7;
+            const double expectedSecondAmount = 553.39;
+            const int expectedThirdVatRate = 0;
+            const int expectedThirdAmount = 14;
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Collection(billInformation.VatDetails,
+                item =>
+                {
+                    Assert.Equal(expectedFirstVatRate, item.Key);
+                    Assert.Equal(expectedFirstAmount, item.Value);
+                },
+                item =>
+                {
+                    Assert.Equal(expectedSecondVatRate, item.Key);
+                    Assert.Equal(expectedSecondAmount, item.Value);
+                },
+                item =>
+                {
+                    Assert.Equal(expectedThirdVatRate, item.Key);
+                    Assert.Equal(expectedThirdAmount, item.Value);
+                });
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_VatPureImportTax_IsMapped()
+        {
+            const string rawBillInformation =
+                "//S1/10/4031202511/11/180107/20/61257233.4/30/105493567/32/8:49.82/33/2.5:14.85/40/0:30";
+            const double expectedRate = 2.5;
+            const double expectedAmount = 14.85;
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Collection(billInformation.VatImportTaxes,
+                item =>
+                {
+                    Assert.Equal(expectedRate, item.Key);
+                    Assert.Equal(expectedAmount, item.Value);
+                });
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_NoImportTax_AreEmpty()
+        {
+            const string rawBillInformation = "//S1/10/4031202511/11/180107/20/61257233.4/30/105493567/32/8:49.82";
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Empty(billInformation.VatImportTaxes);
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_SingleCondition_IsMapped()
+        {
+            const string rawBillInformation =
+                "//S1/10/4031202511/11/180107/20/61257233.4/30/105493567/32/8:49.82/33/2.5:14.85/40/0:30";
+            const double expectedDiscount = 0;
+            const int expectedDeadline = 30;
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Collection(billInformation.Conditions,
+                item =>
+                {
+                    Assert.Equal(expectedDiscount, item.Key);
+                    Assert.Equal(expectedDeadline, item.Value);
+                });
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_MultipleConditions_AreMapped()
+        {
+            const string rawBillInformation =
+                "//S1/10/X.66711-8824/11/200712/20/MW-2020-04/30/107978798/32/2.5:117.22/40/3:5;1.5:20;1:40;0:60";
+            const double expectedFirstDiscount = 3;
+            const int expectedFirstDeadline = 5;
+            const double expectedSecondDiscount = 1.5;
+            const int expectedSecondDeadline = 20;
+            const double expectedThirdDiscount = 1;
+            const int expectedThirdDeadline = 40;
+            const double expectedLastDiscount = 0;
+            const int expectedLastDeadline = 60;
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Collection(billInformation.Conditions,
+                item =>
+                {
+                    Assert.Equal(expectedFirstDiscount, item.Key);
+                    Assert.Equal(expectedFirstDeadline, item.Value);
+                },
+                item =>
+                {
+                    Assert.Equal(expectedSecondDiscount, item.Key);
+                    Assert.Equal(expectedSecondDeadline, item.Value);
+                },
+                item =>
+                {
+                    Assert.Equal(expectedThirdDiscount, item.Key);
+                    Assert.Equal(expectedThirdDeadline, item.Value);
+                },
+                item =>
+                {
+                    Assert.Equal(expectedLastDiscount, item.Key);
+                    Assert.Equal(expectedLastDeadline, item.Value);
+                });
+        }
+
+        [Fact]
+        public void DecodeBillInformationText_NoCondition_AreEmpty()
+        {
+            const string rawBillInformation = "//S1/10/4031202511/11/180107/20/61257233.4/30/105493567/32/8:49.82/33/2.5:14.85";
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            Assert.Empty(billInformation.Conditions);
+        }
+
+        [Theory]
+        [InlineData(
+            "//S1/10/100000/11/200114/40/5.00:10;2.00:20;0.00:30", "200213")]
+        [InlineData(
+            "//S1/10/4031202511/11/180107/20/61257233.4/30/105493567/32/8:49.82/33/2.5:14.85/40/0:30", "180206")]
+        [InlineData(
+            "//S1/10/4031202511/11/180107/20/61257233.4/30/105493567/32/8:49.82/33/2.5:14.85/40", null)]
+        [InlineData(
+            "//S1/10/4031202511/20/61257233.4/30/105493567/32/8:49.82/33/2.5:14.85/40/0:30", null)]
+        [InlineData(
+            "//S1/10/4031202511/20/61257233.4/30/105493567/32/8:49.82/33/2.5:14.85/0:30", null)]
+        [InlineData("//S1/10/X.66711-8824/11/200712/20/MW-2020-04/30/107978798/32/2.5:117.22/40/3:5;1.5:20;1:40;0:60",
+            "200910")]
+        public void DecodeBillInformationText_DueDate_IsMapped(string rawBillInformation, string expectedDueDate)
+        {
+            var dueDate = string.IsNullOrEmpty(expectedDueDate)
+                ? (DateTime?) null
+                : DateTime.ParseExact(
+                    expectedDueDate,
+                    "yyMMdd",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None);
+
+            var billInformation = BillInformation.DecodeBillInformationText(rawBillInformation);
+
+            if (string.IsNullOrEmpty(expectedDueDate))
+            {
+                Assert.Null(billInformation.DueDate);
+            }
+            else
+            {
+                Assert.NotNull(billInformation.DueDate);
+                Assert.Equal(dueDate, billInformation.DueDate);
+            }
+        }
+    }
+}

--- a/GeneratorTest/BillTest.cs
+++ b/GeneratorTest/BillTest.cs
@@ -116,10 +116,10 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         {
             Bill bill = new Bill
             {
-                BillInformation = "S1/01/20170309/11/10201409/20/14000000/22/369 58/30/CH106017086/40/1020/41/3010"
+                BillInformationText = "S1/01/20170309/11/10201409/20/14000000/22/369 58/30/CH106017086/40/1020/41/3010"
             };
             Assert.Equal("S1/01/20170309/11/10201409/20/14000000/22/369 58/30/CH106017086/40/1020/41/3010",
-                    bill.BillInformation);
+                    bill.BillInformationText);
         }
 
         [Fact]

--- a/GeneratorTest/CharacterSetTest.cs
+++ b/GeneratorTest/CharacterSetTest.cs
@@ -109,10 +109,10 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         private void BillInfoReplacement()
         {
             SourceBill = SampleData.CreateExample1();
-            SourceBill.BillInformation = "//AZ/400€/123";
+            SourceBill.BillInformationText = "//AZ/400€/123";
             Validate();
             AssertSingleWarningMessage(ValidationConstants.FieldBillInformation, "replaced_unsupported_characters");
-            Assert.Equal("//AZ/400./123", ValidatedBill.BillInformation);
+            Assert.Equal("//AZ/400./123", ValidatedBill.BillInformationText);
         }
 
         [Fact]

--- a/GeneratorTest/QRCodeTest.cs
+++ b/GeneratorTest/QRCodeTest.cs
@@ -51,5 +51,27 @@ namespace Codecrete.SwissQRBill.GeneratorTest
             byte[] svg = QRBill.Generate(bill);
             FileComparison.AssertFileContentsEqual(svg, "qrcode_ex4.svg");
         }
+
+        [Fact]
+        private void DecodeQrCodeText_QRBillWithoutBillingInformation_BillingInfoIsNull()
+        {
+            var bill = SampleData.CreateExample4();
+            TestHelper.NormalizeSourceBill(bill);
+
+            var decodedBill = QRBill.DecodeQrCodeText(QRBill.EncodeQrCodeText(bill));
+
+            Assert.Null(decodedBill.BillInformation);
+        }
+
+        [Fact]
+        private void DecodeQrCodeText_QRBillWithBillingInformation_BillingIsNotNull()
+        {
+            var bill = SampleData.CreateExample1();
+            TestHelper.NormalizeSourceBill(bill);
+
+            var decodedBill = QRBill.DecodeQrCodeText(QRBill.EncodeQrCodeText(bill));
+
+            Assert.NotNull(decodedBill.BillInformation);
+        }
     }
 }

--- a/GeneratorTest/SampleData.cs
+++ b/GeneratorTest/SampleData.cs
@@ -42,8 +42,8 @@ namespace Codecrete.SwissQRBill.GeneratorTest
                 Debtor = debtor,
                 Reference = "210000 000 00313 9471430009017",
                 UnstructuredMessage = "Instruction of 15.09.2019",
-                BillInformation =
-                    "//S1/01/20170309/11/10201409/20/14000000/22/36958/30/CH106017086/40/1020/41/3010",
+                BillInformationText =
+                    "//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180508/32/7.7/40/2:10;0:30",
                 AlternativeSchemes = new List<AlternativeScheme>
                 {
                     new AlternativeScheme {Name = "Ultraviolet", Instruction = "UV;UltraPay005;12345"},
@@ -163,7 +163,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
                 Debtor = debtor,
                 Reference = "210000 000 00313 9471430009017",
                 UnstructuredMessage = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed",
-                BillInformation = "//S1/01/20170309/11/10201409/20/14000000/22/36958/30/CH106017086/40/1020/41/3010",
+                BillInformationText = "//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180508/32/7.7/40/2:10;0:30",
                 Format = { Language = Language.EN }
             };
             return bill;
@@ -185,7 +185,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
                 Currency = "EUR",
                 Reference = "210000 000 00313 9471430009017",
                 UnstructuredMessage = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed",
-                BillInformation = "//S1/01/20170309/11/10201409/20/14000000/22/36958/30/CH106017086/40/1020/41/3010",
+                BillInformationText = "//S1/10/10201409/11/190512/20/1400.000-53/30/106017086/31/180508/32/7.7/40/2:10;0:30",
                 Format = { Language = Language.EN }
             };
             return bill;

--- a/GeneratorTest/SampleQRCodeText.cs
+++ b/GeneratorTest/SampleQRCodeText.cs
@@ -151,7 +151,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
                 Debtor = debtor,
                 Reference = "210000000003139471430009017",
                 UnstructuredMessage = "Order dated 18.06.2020",
-                BillInformation =
+                BillInformationText =
                     "//S1/01/20170309/11/10201409/20/14000000/22/36958/30/CH106017086/40/1020/41/3010",
                 AlternativeSchemes = new List<AlternativeScheme>
                 {

--- a/GeneratorTest/TestHelper.cs
+++ b/GeneratorTest/TestHelper.cs
@@ -51,9 +51,9 @@ namespace Codecrete.SwissQRBill.GeneratorTest
                 bill.UnstructuredMessage = ""; // replace null with empty string
             }
 
-            if (bill.BillInformation == null)
+            if (bill.BillInformationText == null)
             {
-                bill.BillInformation = ""; // replace null with empty string
+                bill.BillInformationText = ""; // replace null with empty string
             }
 
             if (bill.AlternativeSchemes != null)


### PR DESCRIPTION
As promised with this PR the raw text containing the QR billing information is decoded in a structured data model based on the syntax definition of Swico.
I added the new property in the `Bill` class which will be filled only in the `Decode` method of `QRCodeText`.