### PR TITLE
Fix typos

### DIFF
--- a/Generator/Address.cs
+++ b/Generator/Address.cs
@@ -132,7 +132,7 @@ namespace Codecrete.SwissQRBill.Generator
         /// <summary>
         /// Gets or sets the street.
         /// <para>
-        /// The street must be speicfied without house number.
+        /// The street must be specified without house number.
         /// </para>
         /// <para>
         /// Setting this field sets the address type to <see cref="AddressType.Structured"/> unless it's already
@@ -225,7 +225,7 @@ namespace Codecrete.SwissQRBill.Generator
         /// <summary>
         /// Gets or sets the two-letter ISO country code.
         ///  <para>
-        /// The country code is mandatory unless the entire address contains <c>null</c> or emtpy values.
+        /// The country code is mandatory unless the entire address contains <c>null</c> or empty values.
         /// </para>
         /// </summary>
         /// <value>The ISO country code.</value>

--- a/Generator/AlternativeScheme.cs
+++ b/Generator/AlternativeScheme.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Swiss QR Bill Generator for .NET
 // Copyright (c) 2018 Manuel Bleichenbacher
 // Licensed under MIT License
@@ -40,7 +40,7 @@ namespace Codecrete.SwissQRBill.Generator
             return Equals(obj as AlternativeScheme);
         }
 
-        /// <summary>Determines whether the specified alernative scheme is equal to the current alternative scheme.</summary>
+        /// <summary>Determines whether the specified alternative scheme is equal to the current alternative scheme.</summary>
         /// <param name="other">The alternative scheme to compare with the current alternative scheme.</param>
         /// <returns><c>true</c> if the specified object is equal to the current object; otherwise, <c>false</c>.</returns>
         public bool Equals(AlternativeScheme other)

--- a/Generator/BillLayout.cs
+++ b/Generator/BillLayout.cs
@@ -238,7 +238,7 @@ namespace Codecrete.SwissQRBill.Generator
                 double boldTextWidth = _graphics.TextWidth(boldText, fontSize, true);
                 _graphics.PutText(boldText, 0, y, fontSize, true);
 
-                string normalText = TrunacateText(scheme.Instruction, maxWidth - boldTextWidth, fontSize);
+                string normalText = TruncateText(scheme.Instruction, maxWidth - boldTextWidth, fontSize);
                 _graphics.PutText(normalText, boldTextWidth, y, fontSize, false);
                 y -= lineSpacing * PtToMm;
             }
@@ -747,7 +747,7 @@ namespace Codecrete.SwissQRBill.Generator
             return Payments.FormatQrReferenceNumber(refNo);
         }
 
-        private string TrunacateText(string text, double maxWidth, int fontSize)
+        private string TruncateText(string text, double maxWidth, int fontSize)
         {
             const double ellipsisWidth = 0.3528; // mm * font size
 

--- a/Generator/Canvas/CharWidthData.cs
+++ b/Generator/Canvas/CharWidthData.cs
@@ -6,6 +6,7 @@
 //
 
 
+using System;
 
 namespace Codecrete.SwissQRBill.Generator.Canvas
 {
@@ -650,7 +651,14 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// <summary>
         /// Default character width for Arial Bold.
         /// </summary>
+        /// <remarks>Keeping for backward compatibility.</remarks>
+        [Obsolete("Use the properly spelled ArialBoldDefaultWidth instead.")]
         public static readonly ushort ArialBoldDefaultWdith = 611;
+
+        /// <summary>
+        /// Default character width for Arial Bold.
+        /// </summary>
+        public static readonly ushort ArialBoldDefaultWidth = 611;
 
         /// <summary>
         /// Character widths for Arial Bold (range 0x20 to 0x7f).
@@ -862,7 +870,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         public static readonly ushort LiberationSansNormalDefaultWidth = 556;
 
         /// <summary>
-        /// Character widths for LIberation Sans Normal (range 0x20 to 0x7f).
+        /// Character widths for Liberation Sans Normal (range 0x20 to 0x7f).
         /// </summary>
         public static readonly ushort[] LiberationSansNormal_20_7F = {
             278, // 0x20

--- a/Generator/Canvas/FontMetrics.cs
+++ b/Generator/Canvas/FontMetrics.cs
@@ -46,7 +46,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
                 _charDefaultWidth = CharWidthData.ArialNormalDefaultWidth;
                 boldCharWidthx20x7F = CharWidthData.ArialBold_20_7F;
                 boldCharWidthxA0xFF = CharWidthData.ArialBold_A0_FF;
-                boldCharDefaultWidth = CharWidthData.ArialBoldDefaultWdith;
+                boldCharDefaultWidth = CharWidthData.ArialBoldDefaultWidth;
             }
             else if (family.Contains("liberation") && family.Contains("sans"))
             {
@@ -90,7 +90,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         }
 
         /// <summary>
-        /// Gets the font family list (comma separated, same synta as for CSS).
+        /// Gets the font family list (comma separated, same syntax as for CSS).
         /// </summary>
         /// <value>The font family list, comma separated.</value>
         public string FontFamilyList { get; }
@@ -112,7 +112,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         }
 
         /// <summary>
-        /// Gets the distance between the baseline and the bottom of letter extending the farest below the baseline.
+        /// Gets the distance between the baseline and the bottom of letter extending the farthest below the baseline.
         /// </summary>
         /// <param name="fontSize">The font size (in pt).</param>
         /// <returns>The distance (in mm).</returns>
@@ -267,7 +267,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// <param name="lines">The line array to add to.</param>
         /// <param name="text">The text serving as a source for the line.</param>
         /// <param name="start">The start position of the line within the text.</param>
-        /// <param name="end">The end position (exluding) of the line within the text.</param>
+        /// <param name="end">The end position (excluding) of the line within the text.</param>
         private static void AddResultLine(ICollection<string> lines, string text, int start, int end)
         {
             while (end > start && text[end - 1] == ' ')

--- a/Generator/Canvas/ICanvas.cs
+++ b/Generator/Canvas/ICanvas.cs
@@ -10,7 +10,7 @@ using System;
 namespace Codecrete.SwissQRBill.Generator.Canvas
 {
     /// <summary>
-    /// Commonn interface for all output formats to draw the QR bill.
+    /// Common interface for all output formats to draw the QR bill.
     /// <para>
     /// The coordinate system has its origin in the bottom left corner.
     /// The y-axis extends from the bottom to the top.
@@ -53,7 +53,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// <param name="text">The text to draw.</param>
         /// <param name="x">The x position of the text's start (in mm).</param>
         /// <param name="y">The y position of the text's top (in mm).</param>
-        /// <param name="fontSize">Thhe font size (in pt).</param>
+        /// <param name="fontSize">The font size (in pt).</param>
         /// <param name="isBold">Flag indicating if the text is in bold or regular weight.</param>
         void PutText(string text, double x, double y, int fontSize, bool isBold);
 
@@ -84,7 +84,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         void MoveTo(double x, double y);
 
         /// <summary>
-        /// Adds a line segment to the open path from the previous point to the speicifed
+        /// Adds a line segment to the open path from the previous point to the specified
         /// position.
         /// </summary>
         /// <param name="x">The x-coordinate of position.</param>
@@ -92,7 +92,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         void LineTo(double x, double y);
 
         /// <summary>
-        /// Adds a cubic Beziér curve to the open path going from the previous point to the speicifed
+        /// Adds a cubic Beziér curve to the open path going from the previous point to the specified
         /// position. Two control points determine the curve.
         /// </summary>
         /// <param name="x1">The x-coordinate of first control point.</param>
@@ -109,7 +109,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// <param name="x">The rectangle's left position (in mm).</param>
         /// <param name="y">The rectangle's top position (in mm).</param>
         /// <param name="width">The rectangle's width (in mm).</param>
-        /// <param name="height">Trectangle's height (in mm).</param>
+        /// <param name="height">The rectangle's height (in mm).</param>
         void AddRectangle(double x, double y, double width, double height);
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         double Ascender(int fontSize);
 
         /// <summary>
-        /// Gets the distance between the baseline and the bottom of the letter extending the farest below the
+        /// Gets the distance between the baseline and the bottom of the letter extending the farthest below the
         /// baseline.
         /// </summary>
         /// <param name="fontSize">The font size (in pt).</param>

--- a/Generator/Canvas/PNGCanvas.cs
+++ b/Generator/Canvas/PNGCanvas.cs
@@ -44,7 +44,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// </summary>
         /// <param name="width">The image width, in mm.</param>
         /// <param name="height">The image height, in mm.</param>
-        /// <param name="resolution">The resolutionn of the image to generate (in pixels per inch).</param>
+        /// <param name="resolution">The resolution of the image to generate (in pixels per inch).</param>
         /// <param name="fontFamilyList">A list font family names, separated by comma (same syntax as for CSS). The first font family will be used.</param>
         public PNGCanvas(double width, double height, int resolution, string fontFamilyList)
         {

--- a/Generator/Payments.cs
+++ b/Generator/Payments.cs
@@ -518,7 +518,7 @@ namespace Codecrete.SwissQRBill.Generator
             /// <summary>
             /// Gets/sets the flag indicating if unsupported characters have been replaced.
             /// </summary>
-            /// <value>Flag indicating if unsspored characters have been replaced.</value>
+            /// <value>Flag indicating if unsupported characters have been replaced.</value>
             public bool ReplacedUnsupportedChars { get; set; }
         }
 

--- a/Generator/QRBill.cs
+++ b/Generator/QRBill.cs
@@ -94,7 +94,7 @@ namespace Codecrete.SwissQRBill.Generator
         /// validation</a>
         /// </para>
         /// <para>
-        /// The graphics format is specified in <c>bill.Format.GraphisFormat</c>. This method
+        /// The graphics format is specified in <c>bill.Format.GraphicsFormat</c>. This method
         /// only supports the generation of SVG images and PDF files. For other graphics
         /// formats (in particular PNG), use <see cref="Draw(Bill, ICanvas)"/>.
         /// </para>
@@ -127,7 +127,7 @@ namespace Codecrete.SwissQRBill.Generator
         /// Draws the QR bill (payment part and receipt) or QR code for the specified bill data onto the specified canvas.
         /// <para>
         /// The QR bill or code are drawn at position (0, 0) extending to the top and to the right.
-        /// Typcially, the position (0, 0) is the bottom left corner of the canvas.
+        /// Typically, the position (0, 0) is the bottom left corner of the canvas.
         /// </para>
         /// <para>
         /// This methods ignores the formatting properties <c>bill.Format.FontFamily</c> and <c>bill.Format.GraphicsFormat</c>.

--- a/Generator/ValidationConstants.cs
+++ b/Generator/ValidationConstants.cs
@@ -9,7 +9,7 @@
 namespace Codecrete.SwissQRBill.Generator
 {
     /// <summary>
-    /// Constants for bill valdiation messages: message keys and field names.
+    /// Constants for bill validation messages: message keys and field names.
     /// </summary>
     public static class ValidationConstants
     {

--- a/Generator/ValidationMessage.cs
+++ b/Generator/ValidationMessage.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Swiss QR Bill Generator for .NET
 // Copyright (c) 2018 Manuel Bleichenbacher
 // Licensed under MIT License
@@ -14,7 +14,7 @@ namespace Codecrete.SwissQRBill.Generator
     public sealed class ValidationMessage
     {
         /// <summary>
-        /// The type of validatin message.
+        /// The type of validation message.
         /// </summary>
         public enum MessageType
         {

--- a/Generator/ValidationResult.cs
+++ b/Generator/ValidationResult.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Swiss QR Bill Generator for .NET
 // Copyright (c) 2018 Manuel Bleichenbacher
 // Licensed under MIT License
@@ -98,7 +98,7 @@ namespace Codecrete.SwissQRBill.Generator
         /// </summary>
         /// <param name="type">The message type.</param>
         /// <param name="field">The name of the affected field.</param>
-        /// <param name="messageKey">The language-netural message key.</param>
+        /// <param name="messageKey">The language-neutral message key.</param>
         /// <param name="messageParameters">The optional message parameters (text) to be inserted into the localized message.</param>
         /// <seealso cref="ValidationMessage"/>
         public void AddMessage(ValidationMessage.MessageType type, string field, string messageKey, string[] messageParameters = null)

--- a/GeneratorTest/AddressTest.cs
+++ b/GeneratorTest/AddressTest.cs
@@ -182,7 +182,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         }
 
         [Fact]
-        public void ClearTestStructed()
+        public void ClearTestStructured()
         {
             Address address1 = CreateStructuredAddress();
             address1.Clear();

--- a/GeneratorTest/BasicBillValidationTest.cs
+++ b/GeneratorTest/BasicBillValidationTest.cs
@@ -158,7 +158,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         }
 
         [Fact]
-        public void EmptyUnstructureMessage()
+        public void EmptyUnstructuredMessage()
         {
             SourceBill = SampleData.CreateExample1();
             SourceBill.UnstructuredMessage = "   ";

--- a/GeneratorTest/BillDataValidationBase.cs
+++ b/GeneratorTest/BillDataValidationBase.cs
@@ -56,7 +56,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         }
 
         /// <summary>
-        /// Asserts thta the validation succeeded with a single warning
+        /// Asserts that the validation succeeded with a single warning
         /// </summary>
         /// <param name="field">the field that triggered the validation warning</param>
         /// <param name="messageKey">the message key of the validation warning</param>

--- a/GeneratorTest/CharacterSetTest.cs
+++ b/GeneratorTest/CharacterSetTest.cs
@@ -140,7 +140,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         }
 
         [Fact]
-        public void TwoReplacedSuggoratePairsWithWhitespace()
+        public void TwoReplacedSurrogatePairsWithWhitespace()
         {
             SourceBill = SampleData.CreateExample1();
             Address address = CreateValidPerson();

--- a/GeneratorTest/CreditorValidationTest.cs
+++ b/GeneratorTest/CreditorValidationTest.cs
@@ -140,7 +140,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         }
 
         [Fact]
-        public void CreditorWithInvalidCounturyCode2()
+        public void CreditorWithInvalidCountryCode2()
         {
             SourceBill = SampleData.CreateExample1();
             Address address = CreateValidPerson();

--- a/GeneratorTest/FontMetricsTest.cs
+++ b/GeneratorTest/FontMetricsTest.cs
@@ -146,7 +146,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         }
 
         [Fact]
-        public void ForcedWorkbreak()
+        public void ForcedWordBreak()
         {
             string[] lines = _fontMetrics.SplitLines("abcde", 2, 10);
             Assert.Equal(5, lines.Length);
@@ -158,7 +158,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         }
 
         [Fact]
-        public void ForcedWordbreakWithSpaces()
+        public void ForcedWordBreakWithSpaces()
         {
             string[] lines = _fontMetrics.SplitLines("  abcde  ", 2, 10);
             Assert.Equal(5, lines.Length);

--- a/GeneratorTest/ISO11649Test.cs
+++ b/GeneratorTest/ISO11649Test.cs
@@ -28,7 +28,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         [Fact]
         public void ValidWithLowercaseLetters()
         {
-            Assert.True(Payments.IsValidIso11649Reference("RF 44 alll ower case"));
+            Assert.True(Payments.IsValidIso11649Reference("RF 44 all lower case"));
         }
 
         [Fact]


### PR DESCRIPTION
Most typos were found in the comments and in the test method names. For the only typo in the public API (CharWidthData.ArialBoldDefaultWidth) the misspelled one has been marked as obsolete in order not to introduce a breaking change.