### PR TITLE
Pull IToByteArray up to ICanvas

### DIFF
--- a/Generator/Canvas/AbstractCanvas.cs
+++ b/Generator/Canvas/AbstractCanvas.cs
@@ -77,6 +77,8 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
             StrokePath(strokeWidth, color);
         }
 
+        public abstract byte[] ToByteArray();
+
         public void Dispose()
         {
             Dispose(true);

--- a/Generator/Canvas/ICanvas.cs
+++ b/Generator/Canvas/ICanvas.cs
@@ -25,7 +25,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
     /// the QR bill (regular and bold font weight).
     /// </para>
     /// </summary>
-    public interface ICanvas : IDisposable
+    public interface ICanvas : IToByteArray, IDisposable
     {
         /// <summary>
         /// Sets a translation, rotation and scaling for the subsequent operations.

--- a/Generator/Canvas/PDFCanvas.cs
+++ b/Generator/Canvas/PDFCanvas.cs
@@ -18,7 +18,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
     /// The PDF generator currently only supports the Helvetica font.
     /// </para>
     /// </summary>
-    public class PDFCanvas : AbstractCanvas, IToByteArray
+    public class PDFCanvas : AbstractCanvas
     {
         private const float ColorScale = 1f / 255;
         private Document _document;
@@ -242,7 +242,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// The canvas can no longer be used for drawing after calling this method.</para>
         /// </summary>
         /// <returns>The byte array containing the PDF document</returns>
-        public byte[] ToByteArray()
+        public override byte[] ToByteArray()
         {
             MemoryStream buffer = new MemoryStream();
             _document.Save(buffer);

--- a/Generator/Canvas/PNGCanvas.cs
+++ b/Generator/Canvas/PNGCanvas.cs
@@ -22,7 +22,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
     /// PNGs are not an optimal file format for QR bills. Vector formats such a SVG
     /// or PDF are of better quality and use far less processing power to generate
     /// </remarks>
-    public class PNGCanvas : AbstractCanvas, IToByteArray
+    public class PNGCanvas : AbstractCanvas
     {
         private readonly int _resolution;
         private readonly float _coordinateScale;
@@ -84,7 +84,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// The canvas can no longer be used for drawing after calling this method.</para>
         /// </summary>
         /// <returns>The byte array containing the PNG image</returns>
-        public byte[] ToByteArray()
+        public override byte[] ToByteArray()
         {
             _graphics.Dispose();
             _graphics = null;

--- a/Generator/Canvas/SVGCanvas.cs
+++ b/Generator/Canvas/SVGCanvas.cs
@@ -15,7 +15,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
     /// <summary>
     /// Canvas for generating SVG files.
     /// </summary>
-    public class SVGCanvas : AbstractCanvas, IToByteArray
+    public class SVGCanvas : AbstractCanvas
     {
         private static readonly Encoding Utf8WithoutBom = new UTF8Encoding(false);
 
@@ -84,7 +84,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// The canvas can no longer be used for drawing after calling this method.</para>
         /// </summary>
         /// <returns>The byte array containing the SVG document</returns>
-        public byte[] ToByteArray()
+        public override byte[] ToByteArray()
         {
             Close();
             return _buffer.ToArray();

--- a/Generator/QRBill.cs
+++ b/Generator/QRBill.cs
@@ -110,7 +110,7 @@ namespace Codecrete.SwissQRBill.Generator
                 try
                 {
                     ValidateAndGenerate(bill, canvas);
-                    return (canvas as IToByteArray)?.ToByteArray();
+                    return canvas.ToByteArray();
                 }
                 catch (QRBillValidationException)
                 {

--- a/GeneratorTest/QRBillErrorsTest.cs
+++ b/GeneratorTest/QRBillErrorsTest.cs
@@ -103,6 +103,11 @@ namespace Codecrete.SwissQRBill.GeneratorTest
             {
                 throw new NotImplementedException();
             }
+
+            public override byte[] ToByteArray()
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }


### PR DESCRIPTION
So that we can write `canvas.ToByteArray()` instead of `(canvas as IToByteArray)?.ToByteArray()` thus ensuring that the returned `byte[]` is never null.

This may seem like an odd pull request so let me explain. I started playing with enabling [Nullable reference types](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references) on this project. This generates a **lot** of warnings so I decided against a huge pull request and  instead, break them into smaller pull requests for easier reviewing.