### PR TITLE
Parse differen swico date formats 

### DIFF
--- a/Generator/SwicoS1Decoder.cs
+++ b/Generator/SwicoS1Decoder.cs
@@ -217,15 +217,49 @@ namespace Codecrete.SwissQRBill.Generator
 
         private static DateTime? GetDateValue(string dateText)
         {
-            // Validation with 
-            if (DateTime.TryParseExact(
-                dateText,
-                "yyMMdd",
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.None,
-                out var date))
+            if (string.IsNullOrWhiteSpace(dateText))
             {
-                return date;
+                return null;
+            }
+            
+            if (dateText.Length == 6) // Consistent with specifications
+            {
+                // Validation with 
+                if (DateTime.TryParseExact(
+                    dateText,
+                    "yyMMdd",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var date))
+                {
+                    return date;
+                }
+            }
+            else if (dateText.Length == 12) // Not consistent with specifications but seen in production (year, month, day, hour, minute, second)
+            {
+                // Validation with 
+                if (DateTime.TryParseExact(
+                    dateText,
+                    "yyMMddHHmmss",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var date))
+                {
+                    return date.Date;
+                }
+            }
+            else if (dateText.Length == 10) // Not consistent with specifications but seen in production (year, month, day, hour, minute)
+            {
+                // Validation with 
+                if (DateTime.TryParseExact(
+                    dateText,
+                    "yyMMddHHmm",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var date))
+                {
+                    return date.Date;
+                }
             }
 
             return null;

--- a/GeneratorTest/SwicoExamples.cs
+++ b/GeneratorTest/SwicoExamples.cs
@@ -72,5 +72,37 @@ namespace Codecrete.SwissQRBill.GeneratorTest
 
         internal const string Example4Text =
                 @"//S1/10/X.66711\/8824/11/200712/20/MW-2020-04/30/107978798/32/2.5:117.22/40/3:5;1.5:20;1:40;0:60";
+
+        internal static SwicoBillInformation CreateExample5()
+        {
+            return new SwicoBillInformation
+            {
+                InvoiceNumber = "79269",
+                InvoiceDate = new DateTime(2020, 7, 14),
+                CustomerReference = "66359",
+                VatNumber = "109532551",
+                VatRate = 7.7m,
+                PaymentConditions = new List<(decimal, int)> { (0m, 30) }
+            };
+        }
+
+        internal const string Example5Text =
+            "//S1/10/79269/11/200714210713/20/66359/30/109532551/32/7.7/40/0:30";
+
+        internal static SwicoBillInformation CreateExample6()
+        {
+            return new SwicoBillInformation
+            {
+                InvoiceNumber = "802277",
+                InvoiceDate = new DateTime(2020, 7, 1),
+                CustomerReference = "55878",
+                VatNumber = "109532551",
+                VatRate = 7.7m,
+                PaymentConditions = new List<(decimal, int)> { (0m, 30) }
+            };
+        }
+
+        internal const string Example6Text =
+            "//S1/10/802277/11/2007012107/20/55878/30/109532551/32/7.7/40/0:30";
     }
 }

--- a/GeneratorTest/SwicoS1DecodingTest.cs
+++ b/GeneratorTest/SwicoS1DecodingTest.cs
@@ -44,6 +44,20 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         }
 
         [Fact]
+        public void Example5_FullyDecoded()
+        {
+            var billInformation = SwicoBillInformation.DecodeText(SwicoExamples.Example5Text);
+            Assert.Equal(SwicoExamples.CreateExample5(), billInformation);
+        }
+
+        [Fact]
+        public void Example6_FullyDecoded()
+        {
+            var billInformation = SwicoBillInformation.DecodeText(SwicoExamples.Example6Text);
+            Assert.Equal(SwicoExamples.CreateExample6(), billInformation);
+        }
+
+        [Fact]
         public void NullValue_ReturnsNull()
         {
             Assert.Null(SwicoBillInformation.DecodeText(null));


### PR DESCRIPTION
Parse differen swico date formats even when they are not consistent with specifications
UnitTests added

Issue: #24 