### PR TITLE
Remove dependency on the System.Text.Encoding.CodePages NuGet package

### DIFF
--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -40,7 +40,6 @@ The Swiss QR bill library:
   <ItemGroup>
     <PackageReference Include="Net.Codecrete.QrCodeGenerator" Version="1.6.1" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`CodePagesEncodingProvider.Instance` is not part of .NET Standard 2.0 but is available (built-in) on all supported versions of .NET Core, see https://apisof.net/catalog/653e5d69-d3b8-cf7c-2875-7f1822ab1354

So we register the CodePagesEncodingProvider.Instance through reflexion in order to avoid taking a superfluous dependency on the System.Text.Encoding.CodePages NuGet package.

On .NET Framework, this issue is moot since Encoding.GetEncoding(1252) always succeeds.