### PR TITLE
Add a GitHub action to automatically build and run tests on all supported platforms on push

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,40 @@
+name: Continuous Integration
+
+on: push
+
+env:
+  Configuration: Release
+  ContinuousIntegrationBuild: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  package:
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    name: Build and run tests
+    steps:
+      - name: Checkout git repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Retrieve cached NuGet packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+      - name: Restore NuGet packages
+        run: dotnet restore --verbosity normal
+      - name: Build solution
+        run: dotnet build --verbosity normal
+      - name: Run tests
+        run: dotnet test --no-build --verbosity normal --logger:"html;LogFileName=../../TestResults-${{ matrix.os }}.html"
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: TestResults-${{ matrix.os }}.html
+          path: TestResults-${{ matrix.os }}.html

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -37,6 +37,13 @@ The Swiss QR bill library:
     <FileVersion>2.5.3.0</FileVersion>
   </PropertyGroup>
 
+  <PropertyGroup Label="Restoring">
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <!-- https://devblogs.microsoft.com/nuget/enable-repeatable-package-restores-using-a-lock-file/#how-does-nuget-use-the-lock-file -->
+    <RestoreLockedMode Condition="$(ContinuousIntegrationBuild) == 'true'">true</RestoreLockedMode>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Net.Codecrete.QrCodeGenerator" Version="1.6.1" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -52,11 +52,7 @@ The Swiss QR bill library:
   <ItemGroup>
     <None Include="Images\logo.png">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Include="Images\logo.png">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
+      <PackagePath />
     </None>
   </ItemGroup>
 

--- a/Generator/packages.lock.json
+++ b/Generator/packages.lock.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "Net.Codecrete.QrCodeGenerator": {
+        "type": "Direct",
+        "requested": "[1.6.1, )",
+        "resolved": "1.6.1",
+        "contentHash": "xB2BRqgJ+DX4wJwHGckQx59JayEQ8vWJ6raV7FdK81d+krFMLxcKsuGRbIxtBcpa4Z925D/8pNP8qQ2N5JW5YQ==",
+        "dependencies": {
+          "System.Drawing.Common": "4.5.1"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "System.Drawing.Common": {
+        "type": "Direct",
+        "requested": "[4.5.1, )",
+        "resolved": "4.5.1",
+        "contentHash": "GiyeGi/v4xYDz1vCNFwFvhz9k1XddOG7VD3jxRqzRBCbTHji+s3HxxbxtoymuK4OadEpgotI8zQ5+GEEH9sUEQ=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
Current results on the `v3` branch:
Windows: 100% (451/451) ✅
Linux: 96% (435/451) ❌
macOS: 95% (432/451) ❌

Note: the test results can be downloaded as an html report in the job [artifacts](https://github.com/manuelbl/SwissQRBill.NET/actions/runs/1120213953#artifacts).