### PR TITLE
Allow QR code text using carriage return (\r) line ending

### DIFF
--- a/Core/QRCodeText.cs
+++ b/Core/QRCodeText.cs
@@ -138,11 +138,11 @@ namespace Codecrete.SwissQRBill.Generator
         /// <exception cref="QRBillValidationException">The text is in an invalid format.</exception>
         public static Bill Decode(string text)
         {
-            string[] lines = SplitLines(text);
-            if (lines.Length < 31 || lines.Length > 34)
+            IReadOnlyList<string> lines = SplitLines(text);
+            if (lines.Count < 31 || lines.Count > 34)
             {
                 // A line feed at the end is illegal (cf 4.2.3) but found in practice. Don't be too strict.
-                if (!(lines.Length == 35 && lines[34].Length == 0))
+                if (!(lines.Count == 35 && lines[34].Length == 0))
                 {
                     ThrowSingleValidationError(ValidationConstants.FieldQrType, ValidationConstants.KeyDataStructureInvalid);
                 }
@@ -202,10 +202,10 @@ namespace Codecrete.SwissQRBill.Generator
                 ThrowSingleValidationError(ValidationConstants.FieldTrailer, ValidationConstants.KeyDataStructureInvalid);
             }
 
-            billData.BillInformation = lines.Length > 31 ? lines[31] : "";
+            billData.BillInformation = lines.Count > 31 ? lines[31] : "";
 
             List<AlternativeScheme> alternativeSchemes = null;
-            int numSchemes = lines.Length - 32;
+            int numSchemes = lines.Count - 32;
             // skip empty schemes at end (due to invalid trailing line feed)
             if (numSchemes > 0 && lines[32 + numSchemes - 1].Length == 0)
             {
@@ -235,7 +235,7 @@ namespace Codecrete.SwissQRBill.Generator
         /// <param name="startLine">The index of first line to process.</param>
         /// <param name="isOptional">The flag indicating if the address is optional.</param>
         /// <returns>The decoded address or <c>null</c> if the address is optional and empty.</returns>
-        private static Address DecodeAddress(string[] lines, int startLine, bool isOptional)
+        private static Address DecodeAddress(IReadOnlyList<string> lines, int startLine, bool isOptional)
         {
 
             bool isEmpty = lines[startLine].Length == 0 && lines[startLine + 1].Length == 0
@@ -275,7 +275,7 @@ namespace Codecrete.SwissQRBill.Generator
             return address;
         }
 
-        private static string[] SplitLines(string text)
+        private static IReadOnlyList<string> SplitLines(string text)
         {
             List<string> lines = new List<string>(32);
             int lastPos = 0;
@@ -299,7 +299,7 @@ namespace Codecrete.SwissQRBill.Generator
 
             // add last line
             lines.Add(text.Substring(lastPos, text.Length - lastPos));
-            return lines.ToArray();
+            return lines;
         }
 
         private static void ThrowSingleValidationError(string field, string messageKey)

--- a/Core/QRCodeText.cs
+++ b/Core/QRCodeText.cs
@@ -5,8 +5,10 @@
 // https://opensource.org/licenses/MIT
 //
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using static Codecrete.SwissQRBill.Generator.Address;
@@ -278,27 +280,24 @@ namespace Codecrete.SwissQRBill.Generator
         private static IReadOnlyList<string> SplitLines(string text)
         {
             List<string> lines = new List<string>(32);
-            int lastPos = 0;
-            while (true)
+            using (var reader = new StringReader(text))
             {
-                int pos = text.IndexOf('\n', lastPos);
-                if (pos < 0)
+                while (true)
                 {
-                    break;
+                    string line = reader.ReadLine();
+                    if (line == null)
+                    {
+                        // StringReader.ReadLine() returns null if the last character is a NewLine character, that's why an empty string is manually added if that's the case.
+                        // See https://github.com/dotnet/runtime/issues/27715 and https://docs.microsoft.com/en-us/dotnet/api/system.io.stringreader.readline#remarks
+                        if (text.EndsWith("\n", StringComparison.OrdinalIgnoreCase) || text.EndsWith("\r", StringComparison.OrdinalIgnoreCase))
+                        {
+                            lines.Add("");
+                        }
+                        break;
+                    }
+                    lines.Add(line);
                 }
-
-                int pos2 = pos;
-                if (pos2 > lastPos && text[pos2 - 1] == '\r')
-                {
-                    pos2--;
-                }
-
-                lines.Add(text.Substring(lastPos, pos2 - lastPos));
-                lastPos = pos + 1;
             }
-
-            // add last line
-            lines.Add(text.Substring(lastPos, text.Length - lastPos));
             return lines;
         }
 

--- a/CoreTest/DecodedTextTest.cs
+++ b/CoreTest/DecodedTextTest.cs
@@ -53,84 +53,57 @@ namespace Codecrete.SwissQRBill.CoreTest
             Assert.Equal(bill, bill2);
         }
 
-        [Fact]
-        public void DecodeTextB1A()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void DecodeText1NewLine(string newLine, bool extraNewLine)
         {
             Bill bill = SampleQRCodeText.CreateBillData1();
             TestHelper.NormalizeSourceBill(bill);
-            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText1(false));
+            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText1(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
             Assert.Equal(bill, bill2);
         }
 
-        [Fact]
-        public void DecodeTextB1B()
-        {
-            Bill bill = SampleQRCodeText.CreateBillData1();
-            TestHelper.NormalizeSourceBill(bill);
-            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText1(true));
-            TestHelper.NormalizeDecodedBill(bill2);
-            Assert.Equal(bill, bill2);
-        }
-
-        [Fact]
-        public void DecodeTextB1C()
-        {
-            Bill bill = SampleQRCodeText.CreateBillData1();
-            TestHelper.NormalizeSourceBill(bill);
-            // QR code text with invalid NL at the end
-            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText1(false) + "\n");
-            TestHelper.NormalizeDecodedBill(bill2);
-            Assert.Equal(bill, bill2);
-        }
-
-        [Fact]
-        public void DecodeTextB1D()
-        {
-            Bill bill = SampleQRCodeText.CreateBillData1();
-            TestHelper.NormalizeSourceBill(bill);
-            // QR code text with invalid CRNL at the end
-            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText1(true) + "\r\n");
-            TestHelper.NormalizeDecodedBill(bill2);
-            Assert.Equal(bill, bill2);
-        }
-
-        [Fact]
-        public void DecodeTextB2()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void DecodeText2NewLine(string newLine, bool extraNewLine)
         {
             Bill bill = SampleQRCodeText.CreateBillData2();
             TestHelper.NormalizeSourceBill(bill);
-            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText2(false));
+            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText2(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
             Assert.Equal(bill, bill2);
         }
 
-        [Fact]
-        public void DecodeTextB3()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void DecodeText3NewLine(string newLine, bool extraNewLine)
         {
             Bill bill = SampleQRCodeText.CreateBillData3();
             TestHelper.NormalizeSourceBill(bill);
-            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText3(false));
+            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText3(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
             Assert.Equal(bill, bill2);
         }
 
-        [Fact]
-        public void DecodeTextB4()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void DecodeText4NewLine(string newLine, bool extraNewLine)
         {
             Bill bill = SampleQRCodeText.CreateBillData4();
             TestHelper.NormalizeSourceBill(bill);
-            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText4(false));
+            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText4(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
             Assert.Equal(bill, bill2);
         }
 
-        [Fact]
-        public void DecodeTextB5()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void DecodeText5NewLine(string newLine, bool extraNewLine)
         {
             Bill bill = SampleQRCodeText.CreateBillData5();
             TestHelper.NormalizeSourceBill(bill);
-            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText5(false));
+            Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText5(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
             Assert.Equal(bill, bill2);
         }
@@ -171,7 +144,7 @@ namespace Codecrete.SwissQRBill.CoreTest
         {
             Bill bill = SampleQRCodeText.CreateBillData1();
             TestHelper.NormalizeSourceBill(bill);
-            string qrCodeText = SampleQRCodeText.CreateQrCodeText1(false);
+            string qrCodeText = SampleQRCodeText.CreateQrCodeText1();
             qrCodeText = qrCodeText.Replace("\n0200\n", "\n0201\n");
             Bill bill2 = QRBill.DecodeQrCodeText(qrCodeText);
             TestHelper.NormalizeDecodedBill(bill2);
@@ -189,7 +162,7 @@ namespace Codecrete.SwissQRBill.CoreTest
         [Fact]
         public void DecodeInvalidNumber()
         {
-            string invalidText = SampleQRCodeText.CreateQrCodeText1(false).Replace("3949.75", "1239d49.75");
+            string invalidText = SampleQRCodeText.CreateQrCodeText1().Replace("3949.75", "1239d49.75");
             QRBillValidationException err = Assert.Throws<QRBillValidationException>(
                         () => QRBill.DecodeQrCodeText(invalidText));
             TestHelper.AssertSingleError(err.Result, ValidationConstants.KeyNumberInvalid, ValidationConstants.FieldAmount);
@@ -198,10 +171,21 @@ namespace Codecrete.SwissQRBill.CoreTest
         [Fact]
         public void DecodeMissingEpd()
         {
-            string invalidText = SampleQRCodeText.CreateQrCodeText1(false).Replace("EPD", "E_P");
+            string invalidText = SampleQRCodeText.CreateQrCodeText1().Replace("EPD", "E_P");
             QRBillValidationException err = Assert.Throws<QRBillValidationException>(
                         () => QRBill.DecodeQrCodeText(invalidText));
             TestHelper.AssertSingleError(err.Result, ValidationConstants.KeyDataStructureInvalid, ValidationConstants.FieldTrailer);
+        }
+
+        private class NewLineTheoryData : TheoryData<string, bool>
+        {
+            public NewLineTheoryData()
+            {
+                Add("\n", false);
+                Add("\n", true);
+                Add("\r\n", false);
+                Add("\r\n", true);
+            }
         }
     }
 }

--- a/CoreTest/DecodedTextTest.cs
+++ b/CoreTest/DecodedTextTest.cs
@@ -185,6 +185,8 @@ namespace Codecrete.SwissQRBill.CoreTest
                 Add("\n", true);
                 Add("\r\n", false);
                 Add("\r\n", true);
+                Add("\r", false);
+                Add("\r", true);
             }
         }
     }

--- a/CoreTest/EncodedTextTest.cs
+++ b/CoreTest/EncodedTextTest.cs
@@ -16,35 +16,35 @@ namespace Codecrete.SwissQRBill.CoreTest
         public void CreateText1()
         {
             Bill bill = SampleQRCodeText.CreateBillData1();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText1(false), QRBill.EncodeQrCodeText(bill));
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText1(), QRBill.EncodeQrCodeText(bill));
         }
 
         [Fact]
         public void CreateText2()
         {
             Bill bill = SampleQRCodeText.CreateBillData2();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText2(false), QRBill.EncodeQrCodeText(bill));
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText2(), QRBill.EncodeQrCodeText(bill));
         }
 
         [Fact]
         public void CreateText3()
         {
             Bill bill = SampleQRCodeText.CreateBillData3();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText3(false), QRBill.EncodeQrCodeText(bill));
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText3(), QRBill.EncodeQrCodeText(bill));
         }
 
         [Fact]
         public void CreateText4()
         {
             Bill bill = SampleQRCodeText.CreateBillData4();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText4(false), QRBill.EncodeQrCodeText(bill));
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText4(), QRBill.EncodeQrCodeText(bill));
         }
 
         [Fact]
         public void CreateText5()
         {
             Bill bill = SampleQRCodeText.CreateBillData5();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText5(false), QRBill.EncodeQrCodeText(bill));
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText5(), QRBill.EncodeQrCodeText(bill));
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Codecrete.SwissQRBill.CoreTest
             Assert.False(result.HasErrors);
             bill = result.CleanedBill;
             bill.Reference = "";
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText3(false), QRBill.EncodeQrCodeText(bill));
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText3(), QRBill.EncodeQrCodeText(bill));
         }
     }
 }

--- a/CoreTest/SampleQRCodeText.cs
+++ b/CoreTest/SampleQRCodeText.cs
@@ -12,41 +12,43 @@ namespace Codecrete.SwissQRBill.CoreTest
 {
     public class SampleQRCodeText
     {
-        private static readonly string QRCodeText1 = "SPC\n" +
-            "0200\n" +
-            "1\n" +
-            "CH5800791123000889012\n" +
-            "S\n" +
-            "Robert Schneider AG\n" +
-            "Rue du Lac\n" +
-            "1268\n" +
-            "2501\n" +
-            "Biel\n" +
-            "CH\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "3949.75\n" +
-            "CHF\n" +
-            "S\n" +
-            "Pia Rutschmann\n" +
-            "Marktgasse\n" +
-            "28\n" +
-            "9400\n" +
-            "Rorschach\n" +
-            "CH\n" +
-            "NON\n" +
-            "\n" +
-            "Bill no. 3139 for gardening work and disposal of waste material\n" +
-            "EPD";
+        private static readonly string[] QRCodeText1 = {
+            "SPC",
+            "0200",
+            "1",
+            "CH5800791123000889012",
+            "S",
+            "Robert Schneider AG",
+            "Rue du Lac",
+            "1268",
+            "2501",
+            "Biel",
+            "CH",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "3949.75",
+            "CHF",
+            "S",
+            "Pia Rutschmann",
+            "Marktgasse",
+            "28",
+            "9400",
+            "Rorschach",
+            "CH",
+            "NON",
+            "",
+            "Bill no. 3139 for gardening work and disposal of waste material",
+            "EPD"
+        };
 
-        public static string CreateQrCodeText1(bool withCrLf)
+        public static string CreateQrCodeText1(string newLine = "\n")
         {
-            return HandleLinefeed(QRCodeText1, withCrLf);
+            return string.Join(newLine, QRCodeText1);
         }
 
         public static Bill CreateBillData1()
@@ -82,44 +84,46 @@ namespace Codecrete.SwissQRBill.CoreTest
             return bill;
         }
 
-        private static readonly string QRCodeText2 = "SPC\n" +
-            "0200\n" +
-            "1\n" +
-            "CH4431999123000889012\n" +
-            "S\n" +
-            "Robert Schneider AG\n" +
-            "Rue du Lac\n" +
-            "1268\n" +
-            "2501\n" +
-            "Biel\n" +
-            "CH\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "1949.75\n" +
-            "CHF\n" +
-            "S\n" +
-            "Pia-Maria Rutschmann-Schnyder\n" +
-            "Grosse Marktgasse\n" +
-            "28\n" +
-            "9400\n" +
-            "Rorschach\n" +
-            "CH\n" +
-            "QRR\n" +
-            "210000000003139471430009017\n" +
-            "Order dated 18.06.2020\n" +
-            "EPD\n" +
-            "//S1/01/20170309/11/10201409/20/14000000/22/36958/30/CH106017086/40/1020/41/3010\n" +
-            "UV;UltraPay005;12345\n" +
-            "XY;XYService;54321";
+        private static readonly string[] QRCodeText2 = {
+            "SPC",
+            "0200",
+            "1",
+            "CH4431999123000889012",
+            "S",
+            "Robert Schneider AG",
+            "Rue du Lac",
+            "1268",
+            "2501",
+            "Biel",
+            "CH",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "1949.75",
+            "CHF",
+            "S",
+            "Pia-Maria Rutschmann-Schnyder",
+            "Grosse Marktgasse",
+            "28",
+            "9400",
+            "Rorschach",
+            "CH",
+            "QRR",
+            "210000000003139471430009017",
+            "Order dated 18.06.2020",
+            "EPD",
+            "//S1/01/20170309/11/10201409/20/14000000/22/36958/30/CH106017086/40/1020/41/3010",
+            "UV;UltraPay005;12345",
+            "XY;XYService;54321"
+        };
 
-        public static string CreateQrCodeText2(bool withCrLf)
+        public static string CreateQrCodeText2(string newLine = "\n")
         {
-            return HandleLinefeed(QRCodeText2, withCrLf);
+            return string.Join(newLine, QRCodeText2);
         }
 
         public static Bill CreateBillData2()
@@ -163,41 +167,43 @@ namespace Codecrete.SwissQRBill.CoreTest
             return bill;
         }
 
-        private static readonly string QRCodeText3 = "SPC\n" +
-            "0200\n" +
-            "1\n" +
-            "CH3709000000304442225\n" +
-            "S\n" +
-            "Salvation Army Foundation Switzerland\n" +
-            "\n" +
-            "\n" +
-            "3000\n" +
-            "Bern\n" +
-            "CH\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "CHF\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "NON\n" +
-            "\n" +
-            "Donnation to the Winterfest campaign\n" +
-            "EPD";
+        private static readonly string[] QRCodeText3 = {
+            "SPC",
+            "0200",
+            "1",
+            "CH3709000000304442225",
+            "S",
+            "Salvation Army Foundation Switzerland",
+            "",
+            "",
+            "3000",
+            "Bern",
+            "CH",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "CHF",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "NON",
+            "",
+            "Donnation to the Winterfest campaign",
+            "EPD"
+        };
 
-        public static string CreateQrCodeText3(bool withCrLf)
+        public static string CreateQrCodeText3(string newLine = "\n")
         {
-            return HandleLinefeed(QRCodeText3, withCrLf);
+            return string.Join(newLine, QRCodeText3);
         }
 
         public static Bill CreateBillData3()
@@ -220,41 +226,44 @@ namespace Codecrete.SwissQRBill.CoreTest
             return bill;
         }
 
-        private static readonly string QRCodeText4 = "SPC\n" +
-            "0200\n" +
-            "1\n" +
-            "CH5800791123000889012\n" +
-            "S\n" +
-            "Robert Schneider AG\n" +
-            "Rue du Lac\n" +
-            "1268\n" +
-            "2501\n" +
-            "Biel\n" +
-            "CH\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "199.95\n" +
-            "CHF\n" +
-            "K\n" +
-            "Pia-Maria Rutschmann-Schnyder\n" +
-            "Grosse Marktgasse 28\n" +
-            "9400 Rorschach\n" +
-            "\n" +
-            "\n" +
-            "CH\n" +
-            "SCOR\n" +
-            "RF18539007547034\n" +
-            "\n" +
-            "EPD";
-
-        public static string CreateQrCodeText4(bool withCrLf)
+        private static readonly string[] QRCodeText4 =
         {
-            return HandleLinefeed(QRCodeText4, withCrLf);
+            "SPC",
+            "0200",
+            "1",
+            "CH5800791123000889012",
+            "S",
+            "Robert Schneider AG",
+            "Rue du Lac",
+            "1268",
+            "2501",
+            "Biel",
+            "CH",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "199.95",
+            "CHF",
+            "K",
+            "Pia-Maria Rutschmann-Schnyder",
+            "Grosse Marktgasse 28",
+            "9400 Rorschach",
+            "",
+            "",
+            "CH",
+            "SCOR",
+            "RF18539007547034",
+            "",
+            "EPD"
+        };
+
+        public static string CreateQrCodeText4(string newLine = "\n")
+        {
+            return string.Join(newLine, QRCodeText4);
         }
 
         public static Bill CreateBillData4()
@@ -288,41 +297,44 @@ namespace Codecrete.SwissQRBill.CoreTest
             return bill;
         }
 
-        private static readonly string QRCodeText5 = "SPC\n" +
-            "0200\n" +
-            "1\n" +
-            "CH5800791123000889012\n" +
-            "S\n" +
-            "Robert Schneider AG\n" +
-            "Rue du Lac\n" +
-            "1268\n" +
-            "2501\n" +
-            "Biel\n" +
-            "CH\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "\n" +
-            "0.50\n" +
-            "CHF\n" +
-            "K\n" +
-            "Pia-Maria Rutschmann-Schnyder\n" +
-            "Grosse Marktgasse 28\n" +
-            "9400 Rorschach\n" +
-            "\n" +
-            "\n" +
-            "CH\n" +
-            "SCOR\n" +
-            "RF18539007547034\n" +
-            "\n" +
-            "EPD";
-
-        public static string CreateQrCodeText5(bool withCrLf)
+        private static readonly string[] QRCodeText5 =
         {
-            return HandleLinefeed(QRCodeText5, withCrLf);
+            "SPC",
+            "0200",
+            "1",
+            "CH5800791123000889012",
+            "S",
+            "Robert Schneider AG",
+            "Rue du Lac",
+            "1268",
+            "2501",
+            "Biel",
+            "CH",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "0.50",
+            "CHF",
+            "K",
+            "Pia-Maria Rutschmann-Schnyder",
+            "Grosse Marktgasse 28",
+            "9400 Rorschach",
+            "",
+            "",
+            "CH",
+            "SCOR",
+            "RF18539007547034",
+            "",
+            "EPD",
+        };
+
+        public static string CreateQrCodeText5(string newLine = "\n")
+        {
+            return string.Join(newLine, QRCodeText5);
         }
 
         public static Bill CreateBillData5()
@@ -354,16 +366,6 @@ namespace Codecrete.SwissQRBill.CoreTest
                 Format = { Language = Language.EN }
             };
             return bill;
-        }
-
-        private static string HandleLinefeed(string text, bool withCrLf)
-        {
-            if (withCrLf)
-            {
-                text = text.Replace("\n", "\r\n");
-            }
-
-            return text;
         }
     }
 }


### PR DESCRIPTION
The Swiss Implementation Guidelines for the QR-bill explicitly forbids CR as line ending:
> All data elements must be present. If the data element has no content, at least a new line must be present (CR + LF or LF, but not CR alone)

But some QR-bills were found in practice using CR as line ending. ¯\_(ツ)_/¯