### PR TITLE
Set ContinuousIntegrationBuild = true only in Release configuration

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -50,7 +50,7 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and other
   <PropertyGroup Label="Packaging">
     <DebugType>embedded</DebugType>
     <EmbedAllSources>true</EmbedAllSources>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild Condition="$(Configuration) == 'Release'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PixelCanvas/PixelCanvas.csproj
+++ b/PixelCanvas/PixelCanvas.csproj
@@ -50,7 +50,7 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and other
   <PropertyGroup Label="Packaging">
     <DebugType>embedded</DebugType>
     <EmbedAllSources>true</EmbedAllSources>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild Condition="$(Configuration) == 'Release'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Windows/Windows.csproj
+++ b/Windows/Windows.csproj
@@ -49,7 +49,7 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and platf
   <PropertyGroup Label="Packaging">
     <DebugType>embedded</DebugType>
     <EmbedAllSources>true</EmbedAllSources>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild Condition="$(Configuration) == 'Release'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This breaks debugging unit tests. Anyway, it's already set by the continuous integration workflow:
> env:
>   Configuration: Release
>   ContinuousIntegrationBuild: true