### PR TITLE
Add possibility to encode the QR code text with CRLF

### DIFF
--- a/Core/Bill.cs
+++ b/Core/Bill.cs
@@ -44,6 +44,22 @@ namespace Codecrete.SwissQRBill.Generator
         }
 
         /// <summary>
+        /// The allowed line separators according to the Swiss Implementation Guidelines for the QR-bill (§ 4.1.4 Separator element)
+        /// </summary>
+        public enum QrDataSeparator
+        {
+            /// <summary>
+            /// Separate lines with the line feed (␊) character, i.e. unicode U+000A.
+            /// </summary>
+            Lf,
+
+            /// <summary>
+            /// Separate lines with the carriage return (␍) character and line feed (␊) characters, i.e. unicode U+000D and U+000A.
+            /// </summary>
+            CrLf,
+        }
+
+        /// <summary>
         /// Gets or sets the version of the QR bill standard.
         /// </summary>
         /// <value>The QR bill standard version.</value>
@@ -244,6 +260,12 @@ namespace Codecrete.SwissQRBill.Generator
         /// <value>The bill formatting information.</value>
         public BillFormat Format { get; set; } = new BillFormat();
 
+        /// <summary>
+        /// Gets or sets the line separator for the QR code data fields.
+        /// </summary>
+        /// <value>The line separator for the QR code data fields.</value>
+        public QrDataSeparator Separator { get; set; } = QrDataSeparator.Lf;
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns><c>true</c> if the specified object is equal to the current object; otherwise, <c>false</c>.</returns>
@@ -269,7 +291,8 @@ namespace Codecrete.SwissQRBill.Generator
                    UnstructuredMessage == other.UnstructuredMessage &&
                    BillInformation == other.BillInformation &&
                    SequenceEqual(AlternativeSchemes, other.AlternativeSchemes) &&
-                   EqualityComparer<BillFormat>.Default.Equals(Format, other.Format);
+                   EqualityComparer<BillFormat>.Default.Equals(Format, other.Format) &&
+                   Separator == other.Separator;
         }
 
         /// <summary>Gets the hash code for this instance.</summary>
@@ -289,6 +312,7 @@ namespace Codecrete.SwissQRBill.Generator
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(BillInformation);
             hashCode = hashCode * -1521134295 + EqualityComparer<List<AlternativeScheme>>.Default.GetHashCode(AlternativeSchemes);
             hashCode = hashCode * -1521134295 + EqualityComparer<BillFormat>.Default.GetHashCode(Format);
+            hashCode = hashCode * -1521134295 + EqualityComparer<QrDataSeparator>.Default.GetHashCode(Separator);
             return hashCode;
         }
 

--- a/Core/Validator.cs
+++ b/Core/Validator.cs
@@ -44,6 +44,7 @@ namespace Codecrete.SwissQRBill.Generator
         {
 
             _billOut.Format = _billIn.Format != null ? new BillFormat(_billIn.Format) : null;
+            _billOut.Separator = _billIn.Separator;
             _billOut.Version = _billIn.Version;
 
             ValidateAccountNumber();

--- a/CoreTest/DecodedTextTest.cs
+++ b/CoreTest/DecodedTextTest.cs
@@ -55,9 +55,9 @@ namespace Codecrete.SwissQRBill.CoreTest
 
         [Theory]
         [ClassData(typeof(NewLineTheoryData))]
-        public void DecodeText1NewLine(string newLine, bool extraNewLine)
+        public void DecodeText1NewLine(Bill.QrDataSeparator separator, string newLine, bool extraNewLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData1();
+            Bill bill = SampleQRCodeText.CreateBillData1(separator);
             TestHelper.NormalizeSourceBill(bill);
             Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText1(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
@@ -66,9 +66,9 @@ namespace Codecrete.SwissQRBill.CoreTest
 
         [Theory]
         [ClassData(typeof(NewLineTheoryData))]
-        public void DecodeText2NewLine(string newLine, bool extraNewLine)
+        public void DecodeText2NewLine(Bill.QrDataSeparator separator, string newLine, bool extraNewLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData2();
+            Bill bill = SampleQRCodeText.CreateBillData2(separator);
             TestHelper.NormalizeSourceBill(bill);
             Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText2(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
@@ -77,9 +77,9 @@ namespace Codecrete.SwissQRBill.CoreTest
 
         [Theory]
         [ClassData(typeof(NewLineTheoryData))]
-        public void DecodeText3NewLine(string newLine, bool extraNewLine)
+        public void DecodeText3NewLine(Bill.QrDataSeparator separator, string newLine, bool extraNewLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData3();
+            Bill bill = SampleQRCodeText.CreateBillData3(separator);
             TestHelper.NormalizeSourceBill(bill);
             Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText3(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
@@ -88,9 +88,9 @@ namespace Codecrete.SwissQRBill.CoreTest
 
         [Theory]
         [ClassData(typeof(NewLineTheoryData))]
-        public void DecodeText4NewLine(string newLine, bool extraNewLine)
+        public void DecodeText4NewLine(Bill.QrDataSeparator separator, string newLine, bool extraNewLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData4();
+            Bill bill = SampleQRCodeText.CreateBillData4(separator);
             TestHelper.NormalizeSourceBill(bill);
             Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText4(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
@@ -99,9 +99,9 @@ namespace Codecrete.SwissQRBill.CoreTest
 
         [Theory]
         [ClassData(typeof(NewLineTheoryData))]
-        public void DecodeText5NewLine(string newLine, bool extraNewLine)
+        public void DecodeText5NewLine(Bill.QrDataSeparator separator, string newLine, bool extraNewLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData5();
+            Bill bill = SampleQRCodeText.CreateBillData5(separator);
             TestHelper.NormalizeSourceBill(bill);
             Bill bill2 = QRBill.DecodeQrCodeText(SampleQRCodeText.CreateQrCodeText5(newLine) + (extraNewLine ? newLine : ""));
             TestHelper.NormalizeDecodedBill(bill2);
@@ -142,7 +142,7 @@ namespace Codecrete.SwissQRBill.CoreTest
         [Fact]
         public void DecodeIgnoreMinorVersion()
         {
-            Bill bill = SampleQRCodeText.CreateBillData1();
+            Bill bill = SampleQRCodeText.CreateBillData1(Bill.QrDataSeparator.Lf);
             TestHelper.NormalizeSourceBill(bill);
             string qrCodeText = SampleQRCodeText.CreateQrCodeText1();
             qrCodeText = qrCodeText.Replace("\n0200\n", "\n0201\n");
@@ -177,16 +177,16 @@ namespace Codecrete.SwissQRBill.CoreTest
             TestHelper.AssertSingleError(err.Result, ValidationConstants.KeyDataStructureInvalid, ValidationConstants.FieldTrailer);
         }
 
-        private class NewLineTheoryData : TheoryData<string, bool>
+        private class NewLineTheoryData : TheoryData<Bill.QrDataSeparator, string, bool>
         {
             public NewLineTheoryData()
             {
-                Add("\n", false);
-                Add("\n", true);
-                Add("\r\n", false);
-                Add("\r\n", true);
-                Add("\r", false);
-                Add("\r", true);
+                Add(Bill.QrDataSeparator.Lf, "\n", false);
+                Add(Bill.QrDataSeparator.Lf, "\n", true);
+                Add(Bill.QrDataSeparator.CrLf, "\r\n", false);
+                Add(Bill.QrDataSeparator.CrLf, "\r\n", true);
+                Add(Bill.QrDataSeparator.Lf, "\r", false);
+                Add(Bill.QrDataSeparator.Lf, "\r", true);
             }
         }
     }

--- a/CoreTest/EncodedTextTest.cs
+++ b/CoreTest/EncodedTextTest.cs
@@ -12,39 +12,45 @@ namespace Codecrete.SwissQRBill.CoreTest
 {
     public class EncodedTextTest
     {
-        [Fact]
-        public void CreateText1()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void CreateText1(Bill.QrDataSeparator separator, string newLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData1();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText1(), QRBill.EncodeQrCodeText(bill));
+            Bill bill = SampleQRCodeText.CreateBillData1(separator);
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText1(newLine), QRBill.EncodeQrCodeText(bill));
         }
 
-        [Fact]
-        public void CreateText2()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void CreateText2(Bill.QrDataSeparator separator, string newLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData2();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText2(), QRBill.EncodeQrCodeText(bill));
+            Bill bill = SampleQRCodeText.CreateBillData2(separator);
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText2(newLine), QRBill.EncodeQrCodeText(bill));
         }
 
-        [Fact]
-        public void CreateText3()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void CreateText3(Bill.QrDataSeparator separator, string newLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData3();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText3(), QRBill.EncodeQrCodeText(bill));
+            Bill bill = SampleQRCodeText.CreateBillData3(separator);
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText3(newLine), QRBill.EncodeQrCodeText(bill));
         }
 
-        [Fact]
-        public void CreateText4()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void CreateText4(Bill.QrDataSeparator separator, string newLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData4();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText4(), QRBill.EncodeQrCodeText(bill));
+            Bill bill = SampleQRCodeText.CreateBillData4(separator);
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText4(newLine), QRBill.EncodeQrCodeText(bill));
         }
 
-        [Fact]
-        public void CreateText5()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void CreateText5(Bill.QrDataSeparator separator, string newLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData5();
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText5(), QRBill.EncodeQrCodeText(bill));
+            Bill bill = SampleQRCodeText.CreateBillData5(separator);
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText5(newLine), QRBill.EncodeQrCodeText(bill));
         }
 
         [Fact]
@@ -58,15 +64,26 @@ namespace Codecrete.SwissQRBill.CoreTest
             });
         }
 
-        [Fact]
-        public void CreateTextEmptyReference()
+        [Theory]
+        [ClassData(typeof(NewLineTheoryData))]
+        public void CreateTextEmptyReference(Bill.QrDataSeparator separator, string newLine)
         {
-            Bill bill = SampleQRCodeText.CreateBillData3();
+            Bill bill = SampleQRCodeText.CreateBillData3(separator);
             ValidationResult result = QRBill.Validate(bill);
             Assert.False(result.HasErrors);
             bill = result.CleanedBill;
             bill.Reference = "";
-            Assert.Equal(SampleQRCodeText.CreateQrCodeText3(), QRBill.EncodeQrCodeText(bill));
+            Assert.Equal(SampleQRCodeText.CreateQrCodeText3(newLine), QRBill.EncodeQrCodeText(bill));
         }
+
+        private class NewLineTheoryData : TheoryData<Bill.QrDataSeparator, string>
+        {
+            public NewLineTheoryData()
+            {
+                Add(Bill.QrDataSeparator.Lf, "\n");
+                Add(Bill.QrDataSeparator.CrLf, "\r\n");
+            }
+        }
+
     }
 }

--- a/CoreTest/SampleQRCodeText.cs
+++ b/CoreTest/SampleQRCodeText.cs
@@ -51,7 +51,7 @@ namespace Codecrete.SwissQRBill.CoreTest
             return string.Join(newLine, QRCodeText1);
         }
 
-        public static Bill CreateBillData1()
+        public static Bill CreateBillData1(Bill.QrDataSeparator separator)
         {
             Address creditor = new Address
             {
@@ -79,7 +79,8 @@ namespace Codecrete.SwissQRBill.CoreTest
                 Currency = "CHF",
                 Debtor = debtor,
                 UnstructuredMessage = "Bill no. 3139 for gardening work and disposal of waste material",
-                Format = { Language = Language.EN }
+                Format = { Language = Language.EN },
+                Separator = separator
             };
             return bill;
         }
@@ -126,7 +127,7 @@ namespace Codecrete.SwissQRBill.CoreTest
             return string.Join(newLine, QRCodeText2);
         }
 
-        public static Bill CreateBillData2()
+        public static Bill CreateBillData2(Bill.QrDataSeparator separator)
         {
             Address creditor = new Address
             {
@@ -162,7 +163,8 @@ namespace Codecrete.SwissQRBill.CoreTest
                     new AlternativeScheme {Name = "Ultraviolet", Instruction = "UV;UltraPay005;12345"},
                     new AlternativeScheme {Name = "Xing Yong", Instruction = "XY;XYService;54321"}
                 },
-                Format = { Language = Language.EN }
+                Format = { Language = Language.EN },
+                Separator = separator
             };
             return bill;
         }
@@ -206,7 +208,7 @@ namespace Codecrete.SwissQRBill.CoreTest
             return string.Join(newLine, QRCodeText3);
         }
 
-        public static Bill CreateBillData3()
+        public static Bill CreateBillData3(Bill.QrDataSeparator separator)
         {
             Address creditor = new Address
             {
@@ -221,7 +223,8 @@ namespace Codecrete.SwissQRBill.CoreTest
                 Creditor = creditor,
                 Currency = "CHF",
                 UnstructuredMessage = "Donnation to the Winterfest campaign",
-                Format = { Language = Language.EN }
+                Format = { Language = Language.EN },
+                Separator = separator
             };
             return bill;
         }
@@ -266,7 +269,7 @@ namespace Codecrete.SwissQRBill.CoreTest
             return string.Join(newLine, QRCodeText4);
         }
 
-        public static Bill CreateBillData4()
+        public static Bill CreateBillData4(Bill.QrDataSeparator separator)
         {
             Address creditor = new Address
             {
@@ -292,7 +295,8 @@ namespace Codecrete.SwissQRBill.CoreTest
                 Currency = "CHF",
                 Debtor = debtor,
                 Reference = "RF18539007547034",
-                Format = { Language = Language.EN }
+                Format = { Language = Language.EN },
+                Separator = separator
             };
             return bill;
         }
@@ -337,7 +341,7 @@ namespace Codecrete.SwissQRBill.CoreTest
             return string.Join(newLine, QRCodeText5);
         }
 
-        public static Bill CreateBillData5()
+        public static Bill CreateBillData5(Bill.QrDataSeparator separator)
         {
             Address creditor = new Address
             {
@@ -363,7 +367,8 @@ namespace Codecrete.SwissQRBill.CoreTest
                 Currency = "CHF",
                 Debtor = debtor,
                 Reference = "RF18539007547034",
-                Format = { Language = Language.EN }
+                Format = { Language = Language.EN },
+                Separator = separator
             };
             return bill;
         }


### PR DESCRIPTION
This introduces a new `Separator` property on the `Bill` object which can be either LF (the default) or CR + LF.

The Swiss Implementation Guidelines for the QR-bill (§ 4.1.4 Separator element) allows both:

> The individual elements in the Swiss QR Code according to the Swiss standard are separated from one another with a carriage return. All data elements must be present. If the data element has no content, at least a new line must be present. The same type of carriage return must always be used within a document. The following carriage returns are permitted:
>
> * CR + LF
> * LF

Some other libraries out there manipulating the QR code data absolutely require CR + LF.