### PR TITLE
Update test projets and simplify the Continuous Integration workflow

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,10 +3,11 @@
   "isRoot": true,
   "tools": {
     "dotnet-validate": {
-      "version": "0.0.1-preview.304",
+      "version": "0.0.1-preview.537",
       "commands": [
         "dotnet-validate"
-      ]
+      ],
+      "rollForward": true
     }
   }
 }

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,19 +13,6 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-        dotnet-version: ['481', '6.0', '8.0']
-        framework-version: ['netstandard2.0', 'net6.0']
-        exclude:
-          - os: macos-latest
-            dotnet-version: 481
-          - os: ubuntu-latest
-            dotnet-version: 481
-          - dotnet-version: 481
-            framework-version: net6.0
-          - dotnet-version: 6.0
-            framework-version: netstandard2.0
-          - dotnet-version: 8.0
-            framework-version: netstandard2.0
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Build and run tests
@@ -36,85 +23,51 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-        if: matrix.dotnet-version != '481'
+          dotnet-version: |
+            6.x
+            8.x
 
-      - name: Restore NuGet packages for CoreTest
-        run: dotnet restore --no-dependencies -p:TargetFramework=net${{ matrix.dotnet-version }} --verbosity normal CoreTest
-      - name: Restore library Core
-        run: dotnet restore --verbosity normal Core
-      - name: Build library Core
-        run: dotnet build --configuration Release --no-restore --verbosity normal Core
-      - name: Build test project CoreTest
-        run: dotnet build --configuration Release --no-restore -p:TargetFramework=net${{ matrix.dotnet-version }} --verbosity normal CoreTest
-      - name: Run tests CoreTest
-        run: dotnet test --configuration Release --no-build -P:TargetFramework=net${{ matrix.dotnet-version }} --logger:"html;LogFileName=../../TestResults-CoreTest-${{ matrix.os }}-dotnet_${{ matrix.dotnet-version }}.html" --verbosity normal CoreTest
+      - name: Restore NuGet packages
+        run: dotnet restore
 
-      - name: Restore NuGet packages for PixelCanvasTest
-        run: dotnet restore --no-dependencies -p:TargetFramework=net${{ matrix.dotnet-version }} --verbosity normal PixelCanvasTest
-      - name: Restore library PixelCanvas
-        run: dotnet restore --verbosity normal PixelCanvas
-      - name: Build library PixelCanvas
-        run: dotnet build --configuration Release --no-restore --verbosity normal PixelCanvas
-      - name: Build test project PixelCanvasTest
-        run: dotnet build --configuration Release --no-restore -p:TargetFramework=net${{ matrix.dotnet-version }} --verbosity normal PixelCanvasTest
-      - name: Run tests PixelCanvasTest
-        run: dotnet test --configuration Release --no-build -P:TargetFramework=net${{ matrix.dotnet-version }} --logger:"html;LogFileName=../../TestResults-PixelCanvasTest-${{ matrix.os }}-dotnet_${{ matrix.dotnet-version }}.html" --verbosity normal PixelCanvasTest
+      - name: Build solution
+        run: dotnet build --no-restore --verbosity normal
 
-      - name: Restore NuGet packages for WindowsTest
-        run: dotnet restore --no-dependencies -p:TargetFramework=net${{ matrix.dotnet-version }} --verbosity normal WindowsTest
-        if: startsWith(matrix.os,'windows')
-      - name: Restore library Windows
-        run: dotnet restore --verbosity normal Windows
-        if: startsWith(matrix.os,'windows')
-      - name: Build library Windows
-        run: dotnet build --configuration Release --no-restore --verbosity normal Windows
-        if: startsWith(matrix.os,'windows')
-      - name: Build test project WindowsTest
-        run: dotnet build --configuration Release --no-restore -p:TargetFramework=net${{ matrix.dotnet-version }} --verbosity normal WindowsTest
-        if: startsWith(matrix.os,'windows')
-      - name: Run tests WindowsTest
-        run: dotnet test --configuration Release --no-build -P:TargetFramework=net${{ matrix.dotnet-version }} --logger:"html;LogFileName=../../TestResults-WindowsTest-${{ matrix.os }}-dotnet_${{ matrix.dotnet-version }}.html" --verbosity normal WindowsTest
-        if: startsWith(matrix.os,'windows')
+      - name: Run tests
+        run: dotnet test --no-build --verbosity normal
 
       - name: Upload received files from failing tests
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: Received-${{ runner.os }}-${{ matrix.dotnet-version }}
+          name: Received-${{ runner.os }}
           path: "**/*.received.*"
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: TestResults-${{ runner.os }}-${{ matrix.dotnet-version }}
+          name: TestResults-${{ runner.os }}
           path: TestResults-*.html
 
-      - name: Create and validate NuGet package for Core
-        run: dotnet pack --no-build --verbosity normal Core/Core.csproj
-        if: startsWith(matrix.os,'windows')
-      - name: Create and validate NuGet package for PixelCanvas
-        run: dotnet pack --no-build --verbosity normal PixelCanvas/PixelCanvas.csproj
-        if: startsWith(matrix.os,'windows')
-      - name: Create and validate NuGet package for Windows
-        run: dotnet pack --no-build --verbosity normal WindowsTest/WindowsTest.csproj
+      - name: Create and validate NuGet packages
+        run: dotnet pack --no-build --verbosity normal
         if: startsWith(matrix.os,'windows')
 
       - name: Set up JDK 17 (for SonarQube)
-        if: startsWith(matrix.os,'windows') && matrix.dotnet-version == '8.0'
+        if: startsWith(matrix.os,'windows')
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
       - name: Cache SonarCloud packages
-        if: startsWith(matrix.os,'windows') && matrix.dotnet-version == '8.0'
+        if: startsWith(matrix.os,'windows')
         uses: actions/cache@v4
         with:
           path: ~\.sonar\cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
-        if: startsWith(matrix.os,'windows') && matrix.dotnet-version == '8.0'
+        if: startsWith(matrix.os,'windows')
         id: cache-sonar-scanner
         uses: actions/cache@v4
         with:
@@ -122,13 +75,13 @@ jobs:
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Install SonarCloud scanner
-        if: startsWith(matrix.os,'windows') && matrix.dotnet-version == '8.0' && steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        if: startsWith(matrix.os,'windows') && steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: powershell
         run: |
           New-Item -Path .\.sonar\scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
       - name: Cache dotnet-coverage
-        if: startsWith(matrix.os,'windows') && matrix.dotnet-version == '8.0'
+        if: startsWith(matrix.os,'windows')
         id: cache-dotnet-coverage
         uses: actions/cache@v4
         with:
@@ -136,13 +89,13 @@ jobs:
           key: ${{ runner.os }}-dotnet-coverage
           restore-keys: ${{ runner.os }}-dotnet-coverage
       - name: Install dotnet-coverage
-        if: startsWith(matrix.os,'windows') && matrix.dotnet-version == '8.0' && steps.cache-dotnet-coverage.outputs.cache-hit != 'true'
+        if: startsWith(matrix.os,'windows') && steps.cache-dotnet-coverage.outputs.cache-hit != 'true'
         shell: powershell
         run: |
           New-Item -Path .\.dotnet-coverage -ItemType Directory
           dotnet tool update dotnet-coverage --tool-path .\.dotnet-coverage
       - name: Build and analyze
-        if: startsWith(matrix.os,'windows') && matrix.dotnet-version == '8.0'
+        if: startsWith(matrix.os,'windows')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,7 +50,9 @@ jobs:
           path: TestResults-*.html
 
       - name: Create and validate NuGet packages
-        run: dotnet pack --no-build --verbosity normal
+        run: |
+          dotnet tool restore
+          dotnet pack --no-build --verbosity normal
         if: startsWith(matrix.os,'windows')
 
       - name: Set up JDK 17 (for SonarQube)

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -99,10 +99,10 @@ jobs:
           New-Item -Path .\.dotnet-coverage -ItemType Directory
           dotnet tool update dotnet-coverage --tool-path .\.dotnet-coverage
       - name: Build and analyze
-        if: startsWith(matrix.os,'windows')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: startsWith(matrix.os,'windows') && env.SONAR_TOKEN != ''
         shell: powershell
         run: |
           dotnet clean

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,8 @@ env:
   ContinuousIntegrationBuild: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
+  TERM: xterm-256color
 
 jobs:
   package:

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ bld/
 *.VisualState.xml
 TestResult.xml
 
+# xUnit.net
+TestResults-*
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -40,7 +40,7 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and other
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageVersion>3.3.0</PackageVersion>
-    <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>3.3.0</PackageValidationBaselineVersion>
     <Deterministic>True</Deterministic>
   </PropertyGroup>
 

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -65,7 +65,6 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and other
   </ItemGroup>
 
   <Target Name="ValidateNuGetPackage" AfterTargets="Pack">
-    <Exec Command="dotnet tool restore" />
     <Exec Command="dotnet validate package local $([MSBuild]::EnsureTrailingSlash($(PackageOutputPath)))$(PackageId).$(PackageVersion).nupkg" />
   </Target>
 

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -56,7 +56,6 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and other
 
   <ItemGroup>
     <PackageReference Include="Net.Codecrete.QrCodeGenerator" Version="2.*" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
-
   <PropertyGroup>
     <AssemblyName>Codecrete.SwissQRBill.Core</AssemblyName>
     <RootNamespace>Codecrete.SwissQRBill.Generator</RootNamespace>

--- a/CoreTest/CoreTest.csproj
+++ b/CoreTest/CoreTest.csproj
@@ -1,54 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-
-    <AssemblyName>Codecrete.SwissQRBill.CoreTest</AssemblyName>
-
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Codecrete.SwissQRBill.CoreTest</RootNamespace>
-
-    <Authors>Manuel Bleichenbacher</Authors>
-
-    <Company>Codecrete</Company>
-
-    <Product>Swiss QR Bill</Product>
-
-    <Copyright>Open source published under MIT license</Copyright>
-
-    <PackageLicenseUrl></PackageLicenseUrl>
-
-    <Version>3.3.0</Version>
-
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-	  <None Update="**\*.verified.*">
-		  <ParentExtension>$(ProjectExt.Replace('proj', ''))</ParentExtension>
-		  <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-		  <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-	  </None>
-	  <None Update="**\*.received.*">
-		  <ParentExtension>$(ProjectExt.Replace('proj', ''))</ParentExtension>
-		  <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-		  <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-	  </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="DiffEngine" Version="15.*" />
-    <PackageReference Include="Docnet.Core" Version="2.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
-    <PackageReference Include="Verify.ImageMagick" Version="3.*" />
-    <PackageReference Include="Verify.Xunit" Version="28.7.0" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="Docnet.Core" Version="2.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
+    <PackageReference Include="Verify.ImageMagick" Version="3.7.0" />
+    <PackageReference Include="Verify.Xunit" Version="29.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CoreTest/CoreTest.csproj
+++ b/CoreTest/CoreTest.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="SkiaSharp" Version="3.119.0" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
     <PackageReference Include="Verify.ImageMagick" Version="3.7.0" />
-    <PackageReference Include="Verify.Xunit" Version="29.4.0" />
+    <PackageReference Include="Verify.Xunit" Version="29.5.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
   </ItemGroup>

--- a/CoreTest/CoreTest.csproj
+++ b/CoreTest/CoreTest.csproj
@@ -1,8 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net481;$(TargetFrameworks)</TargetFrameworks>
     <RootNamespace>Codecrete.SwissQRBill.CoreTest</RootNamespace>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <TestResultsFile>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),'..','TestResults-$(MSBuildProjectName)-$(TargetFramework).html'))</TestResultsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <VSTestLogger Include="html%3BLogFileName=$([System.IO.Path]::GetFullPath($(TestResultsFile)))" Visible="false" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <VSTestLogger>@(VSTestLogger)</VSTestLogger>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CoreTest/VerifyImages.cs
+++ b/CoreTest/VerifyImages.cs
@@ -25,7 +25,7 @@ namespace Codecrete.SwissQRBill.CoreTest
 
         static VerifyImages()
         {
-            VerifierSettings.RegisterFileConverter("pdf", ConvertPdfToPng);
+            VerifierSettings.RegisterStreamConverter("pdf", ConvertPdfToPng);
             VerifyImageMagick.RegisterComparers(threshold: 0.1, ImageMagick.ErrorMetric.PerceptualHash);
 
             Settings.UseDirectory("ReferenceFiles");
@@ -33,7 +33,7 @@ namespace Codecrete.SwissQRBill.CoreTest
 
         protected VerifyImages() { }
 
-        private static ConversionResult ConvertPdfToPng(Stream stream, IReadOnlyDictionary<string, object> context)
+        private static ConversionResult ConvertPdfToPng(string name, Stream stream, IReadOnlyDictionary<string, object> context)
         {
             var pngStreams = new List<Stream>();
 
@@ -74,11 +74,6 @@ namespace Codecrete.SwissQRBill.CoreTest
         public static SettingsTask VerifySvg(byte[] svg, [CallerFilePath] string sourceFile = "")
         {
             return Verifier.Verify(svg, settings: Settings, extension: "svg", sourceFile: sourceFile);
-        }
-
-        public static SettingsTask VerifyPng(byte[] png, [CallerFilePath] string sourceFile = "")
-        {
-            return Verifier.Verify(png, settings: Settings, extension: "png", sourceFile: sourceFile);
         }
 
         public static SettingsTask VerifyPdf(byte[] pdf, [CallerFilePath] string sourceFile = "")

--- a/PixelCanvas/PixelCanvas.csproj
+++ b/PixelCanvas/PixelCanvas.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
-
   <PropertyGroup>
     <AssemblyName>Codecrete.SwissQRBill.Generator</AssemblyName>
     <RootNamespace>Codecrete.SwissQRBill.PixelCanvas</RootNamespace>

--- a/PixelCanvas/PixelCanvas.csproj
+++ b/PixelCanvas/PixelCanvas.csproj
@@ -70,7 +70,6 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and other
   </ItemGroup>
 
   <Target Name="ValidateNuGetPackage" AfterTargets="Pack">
-    <Exec Command="dotnet tool restore" />
     <Exec Command="dotnet validate package local $([MSBuild]::EnsureTrailingSlash($(PackageOutputPath)))$(PackageId).$(PackageVersion).nupkg" />
   </Target>
 

--- a/PixelCanvas/PixelCanvas.csproj
+++ b/PixelCanvas/PixelCanvas.csproj
@@ -57,7 +57,6 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and other
 
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="3.*" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PixelCanvas/PixelCanvas.csproj
+++ b/PixelCanvas/PixelCanvas.csproj
@@ -41,7 +41,7 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and other
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageVersion>3.3.0</PackageVersion>
-    <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>3.3.0</PackageValidationBaselineVersion>
     <Deterministic>True</Deterministic>
   </PropertyGroup>
 

--- a/PixelCanvasTest/PixelCanvasTest.csproj
+++ b/PixelCanvasTest/PixelCanvasTest.csproj
@@ -1,58 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Codecrete.SwissQRBill.PixelCanvasTest</RootNamespace>
-
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docnet.Core" Version="2.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
-    <PackageReference Include="Verify.ImageMagick" Version="3.*" />
-    <PackageReference Include="Verify.Xunit" Version="28.7.0" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
+    <PackageReference Include="Verify.ImageMagick" Version="3.7.0" />
+    <PackageReference Include="Verify.Xunit" Version="29.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PixelCanvas\PixelCanvas.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="ReferenceFiles\A4BillTest.CreateA4PngBill1.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
-    <None Update="ReferenceFiles\LineStyleTest.PngWithDashedLines.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
-    <None Update="ReferenceFiles\LineStyleTest.PngWithDottedLines.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
-    <None Update="ReferenceFiles\PNGCanvasTest.PngBillA4.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
-    <None Update="ReferenceFiles\PNGCanvasTest.PngBillQrBill.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/PixelCanvasTest/PixelCanvasTest.csproj
+++ b/PixelCanvasTest/PixelCanvasTest.csproj
@@ -1,8 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net481;$(TargetFrameworks)</TargetFrameworks>
     <RootNamespace>Codecrete.SwissQRBill.PixelCanvasTest</RootNamespace>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <TestResultsFile>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),'..','TestResults-$(MSBuildProjectName)-$(TargetFramework).html'))</TestResultsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <VSTestLogger Include="html%3BLogFileName=$([System.IO.Path]::GetFullPath($(TestResultsFile)))" Visible="false" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <VSTestLogger>@(VSTestLogger)</VSTestLogger>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PixelCanvasTest/PixelCanvasTest.csproj
+++ b/PixelCanvasTest/PixelCanvasTest.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
     <PackageReference Include="Verify.ImageMagick" Version="3.7.0" />
-    <PackageReference Include="Verify.Xunit" Version="29.4.0" />
+    <PackageReference Include="Verify.Xunit" Version="29.5.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
   </ItemGroup>

--- a/Windows/Windows.csproj
+++ b/Windows/Windows.csproj
@@ -69,7 +69,6 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and platf
   </ItemGroup>
 
   <Target Name="ValidateNuGetPackage" AfterTargets="Pack">
-    <Exec Command="dotnet tool restore" />
     <Exec Command="dotnet validate package local $([MSBuild]::EnsureTrailingSlash($(PackageOutputPath)))$(PackageId).$(PackageVersion).nupkg" />
   </Target>
 

--- a/Windows/Windows.csproj
+++ b/Windows/Windows.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
-
   <PropertyGroup>
     <AssemblyName>Codecrete.SwissQRBill.Windows</AssemblyName>
     <RootNamespace>Codecrete.SwissQRBill.Windows</RootNamespace>

--- a/Windows/Windows.csproj
+++ b/Windows/Windows.csproj
@@ -55,7 +55,6 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and platf
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.*" PrivateAssets="all" />
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
   </ItemGroup>
 

--- a/Windows/Windows.csproj
+++ b/Windows/Windows.csproj
@@ -40,7 +40,7 @@ See home page https://github.com/manuelbl/SwissQRBill.NET for examples and platf
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageVersion>3.3.0</PackageVersion>
-    <PackageValidationBaselineVersion>3.0.3</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>3.3.0</PackageValidationBaselineVersion>
     <Deterministic>True</Deterministic>
   </PropertyGroup>
 

--- a/WindowsTest/A4BillTest.cs
+++ b/WindowsTest/A4BillTest.cs
@@ -14,7 +14,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
 {
     public class A4BillTest
     {
-        [Fact]
+        [WindowsFact]
         public Task CreateA4PngBill1()
         {
             return GenerateAndCompareBill(SampleData.CreateExample1(), OutputSize.A4PortraitSheet, GraphicsFormat.PNG);

--- a/WindowsTest/CleanupTest.cs
+++ b/WindowsTest/CleanupTest.cs
@@ -15,7 +15,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
 {
     public class CleanupTest
     {
-        [Fact]
+        [WindowsFact]
         public void ClosePngFreesResources()
         {
             Type type = typeof(BitmapCanvas);

--- a/WindowsTest/EmfCanvasTest.cs
+++ b/WindowsTest/EmfCanvasTest.cs
@@ -24,7 +24,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
             SetProcessDPIAware();
         }
 
-        [Fact]
+        [WindowsFact]
         public Task QrBillExtraSpace_ComparePng()
         {
             Bill bill = SampleData.CreateExample5();
@@ -40,7 +40,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
             return VerifyImages.VerifyEmf(emf);
         }
 
-        [Fact]
+        [WindowsFact]
         public Task QrBillA4_ComparePng()
         {
             Bill bill = SampleData.CreateExample3();
@@ -56,7 +56,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
             return VerifyImages.VerifyEmf(png);
         }
 
-        [Fact]
+        [WindowsFact]
         public void ToStream_RunsSuccessfully()
         {
             Bill bill = SampleData.CreateExample5();
@@ -71,7 +71,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
             Assert.True(true);
         }
 
-        [Fact]
+        [WindowsFact]
         public void ToByteArray_CorrectFrame()
         {
             Bill bill = SampleData.CreateExample4();
@@ -97,7 +97,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
             Assert.InRange(frame.Bottom, expectedHeight - 2, expectedHeight + 2);
         }
 
-        [Fact]
+        [WindowsFact]
         public void ToMetafile_CorrectFrame()
         {
             Bill bill = SampleData.CreateExample6();

--- a/WindowsTest/LineStyleTest.cs
+++ b/WindowsTest/LineStyleTest.cs
@@ -15,14 +15,14 @@ namespace Codecrete.SwissQRBill.WindowsTest
 {
     public class LineStyleTest
     {
-        [Fact]
+        [WindowsFact]
         public Task PngWithDashedLines()
         {
             Bill bill = SampleData.CreateExample1();
             return GenerateAndComparePngBill(bill, SeparatorType.DashedLine);
         }
 
-        [Fact]
+        [WindowsFact]
         public Task PngWithDottedLines()
         {
             Bill bill = SampleData.CreateExample2();

--- a/WindowsTest/PNGCanvasTest.cs
+++ b/WindowsTest/PNGCanvasTest.cs
@@ -16,7 +16,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
 {
     public class PNGCanvasTest
     {
-        [Fact]
+        [WindowsFact]
         public Task PngBillQrBill()
         {
             Bill bill = SampleData.CreateExample1();
@@ -32,7 +32,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
             return VerifyImages.VerifyPng(png);
         }
 
-        [Fact]
+        [WindowsFact]
         public Task PngBillA4()
         {
             Bill bill = SampleData.CreateExample3();
@@ -48,7 +48,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
             return VerifyImages.VerifyPng(png);
         }
 
-        [Fact]
+        [WindowsFact]
         public void PngWriteTo()
         {
             Bill bill = SampleData.CreateExample5();
@@ -63,7 +63,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
             Assert.True(true);
         }
 
-        [Fact]
+        [WindowsFact]
         public void PngSaveAs()
         {
             Bill bill = SampleData.CreateExample6();

--- a/WindowsTest/VerifyImages.cs
+++ b/WindowsTest/VerifyImages.cs
@@ -22,7 +22,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
 
         static VerifyImages()
         {
-            VerifierSettings.RegisterFileConverter("emf", Convert);
+            VerifierSettings.RegisterStreamConverter("emf", Convert);
             VerifyImageMagick.RegisterComparers(threshold: 0.35, ImageMagick.ErrorMetric.PerceptualHash);
 
             Settings.UseDirectory("ReferenceFiles");
@@ -40,7 +40,7 @@ namespace Codecrete.SwissQRBill.WindowsTest
             return Verifier.Verify(emf, settings: Settings, extension: "emf", sourceFile: sourceFile);
         }
 
-        private static ConversionResult Convert(Stream stream, IReadOnlyDictionary<string, object> context)
+        private static ConversionResult Convert(string name, Stream stream, IReadOnlyDictionary<string, object> context)
         {
             MemoryStream result;
 

--- a/WindowsTest/WindowsFactAttribute.cs
+++ b/WindowsTest/WindowsFactAttribute.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Codecrete.SwissQRBill.WindowsTest
+{
+    public sealed class WindowsFactAttribute : FactAttribute
+    {
+        private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public WindowsFactAttribute()
+        {
+            if (!IsWindows)
+            {
+                Skip = "Only supported on Windows";
+            }
+        }
+    }
+}

--- a/WindowsTest/WindowsTest.csproj
+++ b/WindowsTest/WindowsTest.csproj
@@ -1,55 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Codecrete.SwissQRBill.WindowsTest</RootNamespace>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docnet.Core" Version="2.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="Verify.ImageMagick" Version="3.*" />
-    <PackageReference Include="Verify.Xunit" Version="28.7.0" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Verify.ImageMagick" Version="3.7.0" />
+    <PackageReference Include="Verify.Xunit" Version="29.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Windows\Windows.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="ReferenceFiles\A4BillTest.CreateA4PngBill1.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
-    <None Update="ReferenceFiles\LineStyleTest.PngWithDashedLines.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
-    <None Update="ReferenceFiles\LineStyleTest.PngWithDottedLines.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
-    <None Update="ReferenceFiles\PNGCanvasTest.PngBillA4.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
-    <None Update="ReferenceFiles\PNGCanvasTest.PngBillQrBill.verified.png">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <ParentExtension>$(MSBuildProjectExtension.Replace('proj', ''))</ParentExtension>
-      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/WindowsTest/WindowsTest.csproj
+++ b/WindowsTest/WindowsTest.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Verify.ImageMagick" Version="3.7.0" />
-    <PackageReference Include="Verify.Xunit" Version="29.4.0" />
+    <PackageReference Include="Verify.Xunit" Version="29.5.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
   </ItemGroup>

--- a/WindowsTest/WindowsTest.csproj
+++ b/WindowsTest/WindowsTest.csproj
@@ -1,8 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net481;$(TargetFrameworks)</TargetFrameworks>
     <RootNamespace>Codecrete.SwissQRBill.WindowsTest</RootNamespace>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <TestResultsFile>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),'..','TestResults-$(MSBuildProjectName)-$(TargetFramework).html'))</TestResultsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <VSTestLogger Include="html%3BLogFileName=$([System.IO.Path]::GetFullPath($(TestResultsFile)))" Visible="false" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <VSTestLogger>@(VSTestLogger)</VSTestLogger>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Remove DiffEngine package reference (it would fail with NU1605: Detected package downgrade: DiffEngine from 16.2.1 to 15.11.0)
* Simplify projects
* Don't use floating version. For example, 2.* resolves to 2.0.0 instead of 2.9.3
* Cleanup unused dependencies
* Use Verify.DocNet instead of custom code to convert PDF to PNG
* Fix deprecation warning on VerifierSettings.RegisterFileConverter